### PR TITLE
Releases/v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobsos-evaluation-center",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/add-community-dialog/add-community-dialog.component.html
+++ b/src/app/add-community-dialog/add-community-dialog.component.html
@@ -1,0 +1,11 @@
+<h1 mat-dialog-title>
+  {{ 'app.community-selector.pick-community-name' | translate }}
+</h1>
+<div mat-dialog-content>
+  <mat-form-field appearance="standard">
+    <input [(ngModel)]="name" matInput placeholder="ACIS" />
+  </mat-form-field>
+</div>
+<div mat-dialog-actions [mat-dialog-close]="name">
+  <button mat-flat-button color="primary">Ok</button>
+</div>

--- a/src/app/add-community-dialog/add-community-dialog.component.html
+++ b/src/app/add-community-dialog/add-community-dialog.component.html
@@ -3,15 +3,21 @@
 </h1>
 <div mat-dialog-content>
   <mat-form-field appearance="standard">
-    <input [(ngModel)]="name" matInput placeholder="ACIS" />
+    <input
+      required
+      [formControl]="form"
+      matInput
+      placeholder="ACIS"
+    />
+    <mat-error *ngIf="error$ | async as error">{{ error }}</mat-error>
   </mat-form-field>
 </div>
 <div mat-dialog-actions>
   <button
     mat-flat-button
-    [mat-dialog-close]="name"
+    (click)="onSubmit()"
     color="primary"
-    [disabled]="!(this.name?.trim().length > 0)"
+    [disabled]="!this.form.dirty || (error$ | async)"
   >
     Ok
   </button>

--- a/src/app/add-community-dialog/add-community-dialog.component.html
+++ b/src/app/add-community-dialog/add-community-dialog.component.html
@@ -6,6 +6,16 @@
     <input [(ngModel)]="name" matInput placeholder="ACIS" />
   </mat-form-field>
 </div>
-<div mat-dialog-actions [mat-dialog-close]="name">
-  <button mat-flat-button color="primary">Ok</button>
+<div mat-dialog-actions>
+  <button
+    mat-flat-button
+    [mat-dialog-close]="name"
+    color="primary"
+    [disabled]="!(this.name?.trim().length > 0)"
+  >
+    Ok
+  </button>
+  <button mat-button color="warn" [mat-dialog-close]="undefined">
+    Cancel
+  </button>
 </div>

--- a/src/app/add-community-dialog/add-community-dialog.component.spec.ts
+++ b/src/app/add-community-dialog/add-community-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddCommunityDialogComponent } from './add-community-dialog.component';
+
+describe('AddCommunityDialogComponent', () => {
+  let component: AddCommunityDialogComponent;
+  let fixture: ComponentFixture<AddCommunityDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AddCommunityDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddCommunityDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/add-community-dialog/add-community-dialog.component.ts
+++ b/src/app/add-community-dialog/add-community-dialog.component.ts
@@ -1,0 +1,20 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-add-community-dialog',
+  templateUrl: './add-community-dialog.component.html',
+  styleUrls: ['./add-community-dialog.component.scss'],
+})
+export class AddCommunityDialogComponent implements OnInit {
+  name: string;
+  constructor(
+    private dialogRef: MatDialogRef<AddCommunityDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: string,
+  ) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/add-community-dialog/add-community-dialog.component.ts
+++ b/src/app/add-community-dialog/add-community-dialog.component.ts
@@ -1,20 +1,102 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
 import {
   MatDialogRef,
   MAT_DIALOG_DATA,
 } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { Observable, Subscription } from 'rxjs';
+import { map, withLatestFrom } from 'rxjs/operators';
+import { GroupInformation } from '../models/community.model';
+import { addGroup, storeGroup } from '../services/store.actions';
+import { StateEffects } from '../services/store.effects';
+import { USER_GROUPS } from '../services/store.selectors';
 
 @Component({
   selector: 'app-add-community-dialog',
   templateUrl: './add-community-dialog.component.html',
   styleUrls: ['./add-community-dialog.component.scss'],
 })
-export class AddCommunityDialogComponent implements OnInit {
-  name: string;
+export class AddCommunityDialogComponent
+  implements OnInit, OnDestroy
+{
+  form = new FormControl('', [
+    Validators.required,
+    this.forbiddenNameValidator(),
+  ]);
+
+  groups: GroupInformation[] = [];
+  subscriptions$: Subscription[] = [];
+  error$: Observable<string>;
+  error: string;
   constructor(
     private dialogRef: MatDialogRef<AddCommunityDialogComponent>,
+    private ngrxStore: Store,
+    private effects: StateEffects,
+    private _snackBar: MatSnackBar,
     @Inject(MAT_DIALOG_DATA) public data: string,
   ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    const sub = this.ngrxStore
+      .select(USER_GROUPS)
+      .subscribe((groups) => {
+        this.groups = groups;
+      });
+    this.subscriptions$.push(sub);
+    this.error$ = this.form.valueChanges.pipe(
+      withLatestFrom(this.ngrxStore.select(USER_GROUPS)),
+      map(([input, groups]) => {
+        const group = groups.find((g) => g.name === input);
+        let error: string;
+        if (group) {
+          error = 'This name is already taken';
+        } else if (input?.trim().length === 0) {
+          error = 'Group name cannot be empty';
+        }
+        return error;
+      }),
+    );
+  }
+
+  onSubmit() {
+    const name = this.form.value?.trim();
+    const group = this.groups.find((g) => g.name === name);
+    if (group) {
+      this.error = 'This group name is already taken';
+    } else {
+      this.error = null;
+      this.ngrxStore.dispatch(addGroup({ groupName: name }));
+      this.effects.addGroup$.subscribe((res) => {
+        if ('group' in res && res.group.id) {
+          this._snackBar.open('Group added', null, {
+            duration: 1000,
+          });
+        } else if ('reason' in res) {
+          this._snackBar.open(res.reason.message, 'Ok');
+        }
+        this.dialogRef.close();
+      });
+    }
+  }
+  forbiddenNameValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const group = this.groups?.find(
+        (g) => g.name === control.value?.trim(),
+      );
+      return !control.value || !!group
+        ? { forbiddenName: { value: control.value } }
+        : null;
+    };
+  }
+  ngOnDestroy() {
+    this.subscriptions$.forEach((sub) => sub.unsubscribe());
+  }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -47,8 +47,12 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-divider></mat-divider>
       <mat-nav-list>
+        <a mat-list-item (click)="openAddCommunityDialog()">
+          <mat-icon matListIcon> group_add </mat-icon>
+          {{ 'shared.pages.add-community' | translate }}
+        </a>
+        <mat-divider></mat-divider>
         <a
           mat-list-item
           routerLink="/"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,6 +6,7 @@
     [opened]="!mobileQuery.matches"
   >
     <ng-container *ngIf="(user$ | async)?.signedIn">
+      <!-- group selection -->
       <mat-form-field
         id="community-selection"
         *ngIf="groupsAreLoaded$ | async; else groupsAreLoading"
@@ -72,10 +73,10 @@
           <mat-icon matListIcon>code</mat-icon>
           {{ 'shared.pages.raw-edit' | translate }}
         </a>
-        <a mat-list-item [href]="mobsosSurveysUrl" target="_blank">
+        <!-- <a mat-list-item [href]="mobsosSurveysUrl" target="_blank">
           <mat-icon matListIcon>open_in_browser</mat-icon>
           {{ 'shared.pages.manage-questionnaires' | translate }}
-        </a>
+        </a> -->
         <a mat-list-item [href]="reqBazFrontendUrl" target="_blank">
           <mat-icon matListIcon>open_in_browser</mat-icon>
           {{ 'shared.pages.manage-requirements' | translate }}

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -47,7 +47,7 @@ mat-sidenav-container {
 
     mat-nav-list {
       flex: 1;
-
+      padding-top: 0;
       a {
         color: white;
       }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
-import { async, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import {
   TranslateLoader,
   TranslateModule,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -301,16 +301,5 @@ export class AppComponent implements OnInit, OnDestroy {
       data: null,
       disableClose: true,
     });
-    const communityName = await dialogRef.afterClosed().toPromise();
-    if (communityName?.length > 0) {
-      this.ngrxStore.dispatch(addGroup({ groupName: communityName }));
-    }
-    this.effects.addGroup$.subscribe((res) => {
-      if (res['group'].id) {
-        this._snackBar.open('Group added', null, {
-          duration: 1000,
-        });
-      }
-    });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ import Timer = NodeJS.Timer;
 import { FormControl } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import {
+  addGroup,
   fetchGroups,
   fetchMeasureCatalog,
   fetchServices,
@@ -58,6 +59,8 @@ import { MatIconRegistry } from '@angular/material/icon';
 import { User } from './models/user.model';
 import { GroupInformation } from './models/community.model';
 import { LanguageService } from './services/language.service';
+import { MatDialog } from '@angular/material/dialog';
+import { AddCommunityDialogComponent } from './add-community-dialog/add-community-dialog.component';
 
 // workaround for openidconned-signin
 // remove when the lib imports with "import {UserManager} from 'oidc-client';" instead of "import 'oidc-client';"
@@ -127,6 +130,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private matIconRegistry: MatIconRegistry,
     private domSanitizer: DomSanitizer,
     private ngrxStore: Store,
+    private dialog: MatDialog,
   ) {
     this.matIconRegistry.addSvgIcon(
       'reqbaz-logo',
@@ -286,6 +290,16 @@ export class AppComponent implements OnInit, OnDestroy {
         console.log(a);
       });
       this.subscriptions$.push(sub);
+    }
+  }
+
+  async openAddCommunityDialog() {
+    const dialogRef = this.dialog.open(AddCommunityDialogComponent, {
+      data: null,
+    });
+    const communityName = await dialogRef.afterClosed().toPromise();
+    if (communityName?.length > 0) {
+      this.ngrxStore.dispatch(addGroup({ groupName: communityName }));
     }
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,6 +44,7 @@ import {
   SUCCESS_MODEL,
   _SELECTED_GROUP_ID,
   _SELECTED_SERVICE_NAME,
+  APPLICATION_WORKSPACE,
 } from './services/store.selectors';
 import {
   distinctUntilKeyChanged,
@@ -281,14 +282,16 @@ export class AppComponent implements OnInit, OnDestroy {
 
     if (isDevMode() || !environment.production) {
       // Logging in dev mode
-      sub = this.ngrxStore.subscribe((state) => {
-        console.log(state);
-      });
-      this.subscriptions$.push(sub);
+      // sub = this.ngrxStore.subscribe((state) => {
+      //   console.log(state);
+      // });
+      // this.subscriptions$.push(sub);
 
-      sub = this.ngrxStore.select(SUCCESS_MODEL).subscribe((a) => {
-        console.log(a);
-      });
+      sub = this.ngrxStore
+        .select(APPLICATION_WORKSPACE)
+        .subscribe((a) => {
+          console.log(a);
+        });
       this.subscriptions$.push(sub);
     }
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -296,6 +296,7 @@ export class AppComponent implements OnInit, OnDestroy {
   async openAddCommunityDialog() {
     const dialogRef = this.dialog.open(AddCommunityDialogComponent, {
       data: null,
+      disableClose: true,
     });
     const communityName = await dialogRef.afterClosed().toPromise();
     if (communityName?.length > 0) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -123,17 +123,14 @@ export class AppComponent implements OnInit, OnDestroy {
     private logger: NGXLogger,
     public languageService: LanguageService,
     changeDetectorRef: ChangeDetectorRef,
-    media: MediaMatcher,
     private elementRef: ElementRef,
+    private dialog: MatDialog,
     private swUpdate: SwUpdate,
     private snackBar: MatSnackBar,
     private translate: TranslateService,
     private matIconRegistry: MatIconRegistry,
     private domSanitizer: DomSanitizer,
     private ngrxStore: Store,
-    private dialog: MatDialog,
-    private effects: StateEffects,
-    private _snackBar: MatSnackBar,
   ) {
     this.matIconRegistry.addSvgIcon(
       'reqbaz-logo',
@@ -141,7 +138,7 @@ export class AppComponent implements OnInit, OnDestroy {
         'assets/icons/reqbaz-logo.svg',
       ),
     );
-    this.mobileQuery = media.matchMedia('(max-width: 600px)');
+    this.mobileQuery = window.matchMedia('(max-width: 600px)');
     this.mobileQueryListener = () =>
       changeDetectorRef.detectChanges();
     this.mobileQuery.addEventListener(
@@ -198,7 +195,7 @@ export class AppComponent implements OnInit, OnDestroy {
         ),
         first(),
       )
-      .subscribe(([user, groupId, serviceName]) => {
+      .subscribe(([, groupId, serviceName]) => {
         // only gets called once if user is signed in
         // initial fetching
         this.ngrxStore.dispatch(fetchGroups());
@@ -233,7 +230,7 @@ export class AppComponent implements OnInit, OnDestroy {
         }
       }
     });
-    hammertime.on('panleft', (event) => {
+    hammertime.on('panleft', () => {
       if (this.mobileQuery.matches) {
         this.sidenav.close();
       }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -61,6 +61,7 @@ import { GroupInformation } from './models/community.model';
 import { LanguageService } from './services/language.service';
 import { MatDialog } from '@angular/material/dialog';
 import { AddCommunityDialogComponent } from './add-community-dialog/add-community-dialog.component';
+import { StateEffects } from './services/store.effects';
 
 // workaround for openidconned-signin
 // remove when the lib imports with "import {UserManager} from 'oidc-client';" instead of "import 'oidc-client';"
@@ -131,6 +132,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private domSanitizer: DomSanitizer,
     private ngrxStore: Store,
     private dialog: MatDialog,
+    private effects: StateEffects,
+    private _snackBar: MatSnackBar,
   ) {
     this.matIconRegistry.addSvgIcon(
       'reqbaz-logo',
@@ -302,5 +305,12 @@ export class AppComponent implements OnInit, OnDestroy {
     if (communityName?.length > 0) {
       this.ngrxStore.dispatch(addGroup({ groupName: communityName }));
     }
+    this.effects.addGroup$.subscribe((res) => {
+      if (res['group'].id) {
+        this._snackBar.open('Group added', null, {
+          duration: 1000,
+        });
+      }
+    });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -63,6 +63,7 @@ import { LanguageService } from './services/language.service';
 import { MatDialog } from '@angular/material/dialog';
 import { AddCommunityDialogComponent } from './add-community-dialog/add-community-dialog.component';
 import { StateEffects } from './services/store.effects';
+import { StoreState } from './models/state.model';
 
 // workaround for openidconned-signin
 // remove when the lib imports with "import {UserManager} from 'oidc-client';" instead of "import 'oidc-client';"
@@ -282,17 +283,19 @@ export class AppComponent implements OnInit, OnDestroy {
 
     if (isDevMode() || !environment.production) {
       // Logging in dev mode
-      // sub = this.ngrxStore.subscribe((state) => {
-      //   console.log(state);
-      // });
-      // this.subscriptions$.push(sub);
-
       sub = this.ngrxStore
-        .select(APPLICATION_WORKSPACE)
-        .subscribe((a) => {
-          console.log(a);
+        .pipe(map((store: StoreState) => store.Reducer))
+        .subscribe((state) => {
+          console.log(state);
         });
       this.subscriptions$.push(sub);
+
+      // sub = this.ngrxStore
+      //   .select(APPLICATION_WORKSPACE)
+      //   .subscribe((a) => {
+      //     console.log(a);
+      //   });
+      // this.subscriptions$.push(sub);
     }
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -93,6 +93,7 @@ import { JoinWorkSpaceComponent } from './join-work-space/join-work-space.compon
 import { VisitorComponent } from './visitor/visitor.component';
 import { PickUsernameDialogComponent } from './pick-username-dialog/pick-username-dialog.component';
 import { BottomSheetComponent } from './bottom-sheet/bottom-sheet.component';
+import { AddCommunityDialogComponent } from './add-community-dialog/add-community-dialog.component';
 
 class ImportLoader implements TranslateLoader {
   getTranslation(lang: string): Observable<any> {
@@ -171,6 +172,7 @@ const metaReducers: Array<MetaReducer<any, any>> = [
     VisitorComponent,
     PickUsernameDialogComponent,
     BottomSheetComponent,
+    AddCommunityDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { OidcSigninComponent } from './oidc-signin/oidc-signin.component';
 import { OidcSignoutComponent } from './oidc-signout/oidc-signout.component';
 import { OidcSilentComponent } from './oidc-silent/oidc-silent.component';
+import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { SuccessModelingComponent } from './success-modeling/success-modeling.component';
 import { RawEditComponent } from './raw-edit/raw-edit.component';
@@ -91,6 +92,7 @@ import { WorkspaceManagementComponent } from './workspace-management/workspace-m
 import { JoinWorkSpaceComponent } from './join-work-space/join-work-space.component';
 import { VisitorComponent } from './visitor/visitor.component';
 import { PickUsernameDialogComponent } from './pick-username-dialog/pick-username-dialog.component';
+import { BottomSheetComponent } from './bottom-sheet/bottom-sheet.component';
 
 class ImportLoader implements TranslateLoader {
   getTranslation(lang: string): Observable<any> {
@@ -168,6 +170,7 @@ const metaReducers: Array<MetaReducer<any, any>> = [
     JoinWorkSpaceComponent,
     VisitorComponent,
     PickUsernameDialogComponent,
+    BottomSheetComponent,
   ],
   imports: [
     BrowserModule,
@@ -197,6 +200,7 @@ const metaReducers: Array<MetaReducer<any, any>> = [
     MatListModule,
     MatSlideToggleModule,
     MatButtonModule,
+    MatBottomSheetModule,
     MatTabsModule,
     MatFormFieldModule,
     MatProgressBarModule,

--- a/src/app/bottom-sheet/bottom-sheet.component.html
+++ b/src/app/bottom-sheet/bottom-sheet.component.html
@@ -1,0 +1,5 @@
+<app-requirements-list
+  [successModel]="successModel$ | async"
+  (numberOfRequirements)="setNumberOfRequirements($event.valueOf())"
+>
+</app-requirements-list>

--- a/src/app/bottom-sheet/bottom-sheet.component.spec.ts
+++ b/src/app/bottom-sheet/bottom-sheet.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BottomSheetComponent } from './bottom-sheet.component';
+
+describe('BottomSheetComponent', () => {
+  let component: BottomSheetComponent;
+  let fixture: ComponentFixture<BottomSheetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ BottomSheetComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BottomSheetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/bottom-sheet/bottom-sheet.component.ts
+++ b/src/app/bottom-sheet/bottom-sheet.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit } from '@angular/core';
+import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { Store } from '@ngrx/store';
+import { setNumberOfRequirements } from '../services/store.actions';
+import { SUCCESS_MODEL } from '../services/store.selectors';
+
+@Component({
+  selector: 'app-bottom-sheet',
+  templateUrl: './bottom-sheet.component.html',
+  styleUrls: ['./bottom-sheet.component.scss'],
+})
+export class BottomSheetComponent implements OnInit {
+  numberOfRequirements = 0;
+  successModel$ = this.ngrxStore.select(SUCCESS_MODEL);
+  ngOnInit(): void {}
+
+  constructor(
+    private _bottomSheetRef: MatBottomSheetRef<BottomSheetComponent>,
+    private ngrxStore: Store,
+  ) {}
+
+  openLink(event: MouseEvent): void {
+    this._bottomSheetRef.dismiss();
+    event.preventDefault();
+  }
+
+  setNumberOfRequirements(n: number) {
+    this.numberOfRequirements = n;
+    this.ngrxStore.dispatch(setNumberOfRequirements({ n }));
+  }
+}

--- a/src/app/join-work-space/join-work-space.component.ts
+++ b/src/app/join-work-space/join-work-space.component.ts
@@ -39,7 +39,7 @@ export class JoinWorkSpaceComponent implements OnInit, OnDestroy {
   user$ = this.ngrxStore.select(_USER);
   groupId$: Observable<string>;
   serviceName$: Observable<string>;
-  subscription$: Subscription;
+
   subscriptions$: Subscription[] = [];
   owner: string;
   serviceName: string;
@@ -49,7 +49,6 @@ export class JoinWorkSpaceComponent implements OnInit, OnDestroy {
   private userManager = new UserManager({});
 
   ngOnInit() {
-    this.userManager.createSigninRequest();
     let sub = this.route.params
       .pipe(withLatestFrom(this.user$))
       .subscribe(
@@ -118,7 +117,6 @@ export class JoinWorkSpaceComponent implements OnInit, OnDestroy {
           }
         },
       );
-
     this.subscriptions$.push(sub);
     sub = this.user$
       .pipe(
@@ -138,6 +136,7 @@ export class JoinWorkSpaceComponent implements OnInit, OnDestroy {
           this.router.navigateByUrl('');
         }
       });
+    this.subscriptions$.push(sub);
   }
 
   joinWorkspace() {

--- a/src/app/models/reqbaz.model.ts
+++ b/src/app/models/reqbaz.model.ts
@@ -51,8 +51,10 @@ export interface Requirement {
   numberOfAttachments: number;
   numberOfFollowers: number;
   upVotes: number;
+
   downVotes: number;
   userVoted: string;
+  realized?: Date;
 }
 
 export interface Category {

--- a/src/app/models/reqbaz.model.ts
+++ b/src/app/models/reqbaz.model.ts
@@ -2,7 +2,7 @@ export class ReqbazProject {
   constructor(
     public name: string,
     public id: number,
-    public categoryId: number
+    public categoryId: number,
   ) {}
 
   static fromXml(xml: Element): ReqbazProject {
@@ -21,7 +21,43 @@ export class ReqbazProject {
     const questionnaire = doc.createElement('reqbaz-project');
     questionnaire.setAttribute('name', this.name);
     questionnaire.setAttribute('id', this.id.toString());
-    questionnaire.setAttribute('categoryId', this.categoryId.toString());
+    questionnaire.setAttribute(
+      'categoryId',
+      this.categoryId.toString(),
+    );
     return questionnaire;
   }
+}
+
+export interface Requirement {
+  id: number;
+  name: string;
+  description: string;
+  projectId: number;
+  creator: {
+    id: number;
+    userName: string;
+    firstName: string;
+    lastName: string;
+    admin: false;
+    las2peerId: any;
+    profileImage: string;
+    emailLeadSubscription: boolean;
+    emailFollowSubscription: boolean;
+  };
+  categories: Category[];
+  creationDate: Date;
+  numberOfComments: number;
+  numberOfAttachments: number;
+  numberOfFollowers: number;
+  upVotes: number;
+  downVotes: number;
+  userVoted: string;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  description: string;
+  projectId: number;
 }

--- a/src/app/models/state.model.ts
+++ b/src/app/models/state.model.ts
@@ -1,6 +1,7 @@
 import { GroupCollection } from './community.model';
 import { MeasureCatalog } from './measure.catalog';
 import { IQuestionnaire } from './questionnaire.model';
+import { Requirement } from './reqbaz.model';
 import { ServiceCollection } from './service.model';
 import { SuccessModel } from './success.model';
 import { User } from './user.model';
@@ -30,6 +31,7 @@ export interface AppState {
   currentWorkSpaceOwner: string;
   restricted: boolean;
   numberOfRequirements: number;
+  requirements: Requirement[];
 }
 
 export const INITIAL_APP_STATE: AppState = {
@@ -52,6 +54,7 @@ export const INITIAL_APP_STATE: AppState = {
   currentWorkSpaceOwner: undefined,
   restricted: false,
   numberOfRequirements: 0,
+  requirements: undefined,
 };
 /**
  * What the store looks like

--- a/src/app/models/state.model.ts
+++ b/src/app/models/state.model.ts
@@ -29,6 +29,7 @@ export interface AppState {
   communityWorkspace: CommunityWorkspace;
   currentWorkSpaceOwner: string;
   restricted: boolean;
+  numberOfRequirements: number;
 }
 
 export const INITIAL_APP_STATE: AppState = {
@@ -50,6 +51,7 @@ export const INITIAL_APP_STATE: AppState = {
   communityWorkspace: undefined,
   currentWorkSpaceOwner: undefined,
   restricted: false,
+  numberOfRequirements: 0,
 };
 /**
  * What the store looks like

--- a/src/app/models/visualization.model.ts
+++ b/src/app/models/visualization.model.ts
@@ -8,7 +8,7 @@ export interface VisualizationData {
   [query: string]: VData;
 }
 export interface VData {
-  fetchDate: Date;
+  fetchDate: string;
   data: any[][];
   error?: HttpErrorResponse;
 }

--- a/src/app/raw-edit/raw-edit.component.ts
+++ b/src/app/raw-edit/raw-edit.component.ts
@@ -32,7 +32,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { StateEffects } from '../services/store.effects';
-import { combineLatest, of } from 'rxjs';
+import { combineLatest, of, Subscription } from 'rxjs';
 import { ServiceInformation } from '../models/service.model';
 import { SuccessModel } from '../models/success.model';
 import { MeasureCatalog } from '../models/measure.catalog';
@@ -85,6 +85,7 @@ export class RawEditComponent implements OnInit, OnDestroy {
     map((groupid) => !!groupid && !this.saveInProgress),
   );
 
+  subscriptions$: Subscription[] = [];
   constructor(
     private snackBar: MatSnackBar,
     private translate: TranslateService,
@@ -99,24 +100,29 @@ export class RawEditComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.ngrxStore.dispatch(disableEdit());
-    this.selectedGroupId$
+
+    let sub = this.selectedGroupId$
       .pipe(filter((groupId) => !!groupId))
       .subscribe((groupID) => {
         this.groupID = groupID;
       });
-    this.selectedService$.subscribe((service) => {
+    this.subscriptions$.push(sub);
+    sub = this.selectedService$.subscribe((service) => {
       this.selectedServiceName = service?.name;
     });
-    this.services$.subscribe((services) => {
+    this.subscriptions$.push(sub);
+    sub = this.services$.subscribe((services) => {
       this.serviceMap = services;
     });
-    this.ngrxStore
+    this.subscriptions$.push(sub);
+    sub = this.ngrxStore
       .select(SUCCESS_MODEL_XML)
       .pipe(distinctUntilChanged())
       .subscribe((xml) => {
         this.successModelXml = RawEditComponent.prettifyXml(xml);
       });
-    this.ngrxStore
+    this.subscriptions$.push(sub);
+    sub = this.ngrxStore
       .select(MEASURE_CATALOG_XML)
       .pipe(
         distinctUntilChanged(),
@@ -125,9 +131,12 @@ export class RawEditComponent implements OnInit, OnDestroy {
       .subscribe((xml) => {
         this.measureCatalogXml = RawEditComponent.prettifyXml(xml);
       });
+    this.subscriptions$.push(sub);
   }
 
-  ngOnDestroy(): void {}
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((sub) => sub.unsubscribe());
+  }
 
   registerMeasureEditor(editor) {
     this.measureCatalogEditor = editor;

--- a/src/app/raw-edit/raw-edit.component.ts
+++ b/src/app/raw-edit/raw-edit.component.ts
@@ -7,10 +7,10 @@ import { Store } from '@ngrx/store';
 import {
   disableEdit,
   failureResponse,
-  PostActions,
   saveCatalog,
   saveModel,
   setService,
+  StateActions,
 } from '../services/store.actions';
 import {
   MEASURE_CATALOG,
@@ -187,7 +187,7 @@ export class RawEditComponent implements OnInit, OnDestroy {
         .subscribe((result) => {
           this.saveInProgress = false;
 
-          if (result?.type === PostActions.SUCCESS_RESPONSE) {
+          if (result?.type === StateActions.SUCCESS_RESPONSE) {
             const message = this.translate.instant(
               'raw-edit.measures.snackbar-success',
             );
@@ -229,10 +229,10 @@ export class RawEditComponent implements OnInit, OnDestroy {
         )
         .subscribe(
           (
-            result: { type: PostActions } | typeof failureResponse,
+            result: { type: StateActions } | typeof failureResponse,
           ) => {
             this.saveInProgress = false;
-            if (result?.type === PostActions.SUCCESS_RESPONSE) {
+            if (result?.type === StateActions.SUCCESS_RESPONSE) {
               const message = this.translate.instant(
                 'raw-edit.success-models.snackbar-success',
               );

--- a/src/app/services/interceptor.service.ts
+++ b/src/app/services/interceptor.service.ts
@@ -67,9 +67,8 @@ export class Interceptor implements HttpInterceptor {
         catchError((err) => {
           this.ngrxStore.dispatch(decrementLoading());
 
-          setTimeout(() => {
-            delete this.cachedRequests[req.url];
-          }, 2 * ONE_MINUTE_IN_MS);
+          delete this.cachedRequests[req.url];
+
           if (err.status >= 500) {
             this.unreachableServices[req.url] = true;
           }

--- a/src/app/services/las2peer.service.ts
+++ b/src/app/services/las2peer.service.ts
@@ -212,9 +212,7 @@ export class Las2peerService {
       ngHttpOptions.responseType = options.responseType;
     }
 
-    return this.http
-      .request(options.method, url, ngHttpOptions)
-      .pipe(share());
+    return this.http.request(options.method, url, ngHttpOptions);
   }
 
   async fetchServicesFromDiscovery() {

--- a/src/app/services/las2peer.service.ts
+++ b/src/app/services/las2peer.service.ts
@@ -259,7 +259,10 @@ export class Las2peerService {
       this.CONTACT_GROUPS_PATH,
       groupName,
     );
-    return this.makeRequestAndObserve(url);
+    return this.makeRequestAndObserve(url, {
+      method: 'POST',
+      responseType: 'text',
+    });
   }
 
   fetchServicesFromMobSOSAndObserve() {

--- a/src/app/services/las2peer.service.ts
+++ b/src/app/services/las2peer.service.ts
@@ -104,26 +104,18 @@ export class Las2peerService {
       },
       options,
     );
+
     this.userCredentials = JSON.parse(
       localStorage.getItem('profile'),
     );
-
-    if (this.userCredentials) {
-      const username = this.userCredentials?.preferred_username;
-      const sub = JSON.parse(localStorage.getItem('profile'))?.sub;
-      const token = localStorage.getItem('access_token');
-      options = merge(options, {
-        headers: {
-          Authorization: 'Basic ' + btoa(username + ':' + sub),
-          access_token: token,
-        },
-      });
+    const username = this.userCredentials?.preferred_username;
+    const sub = JSON.parse(localStorage.getItem('profile'))?.sub;
+    const token = localStorage.getItem('access_token');
+    if (username) {
+      options.headers.Authorization =
+        'Basic ' + btoa(username + ':' + sub);
+      options.headers.access_token = token;
     }
-    // if (!environment.production) {
-    //   this.logger.debug(
-    //     'Fetching from ' + url //+ ' with options ' + JSON.stringify(options)
-    //   );
-    // }
 
     const ngHttpOptions: {
       body?: any;
@@ -142,7 +134,7 @@ export class Las2peerService {
       reportProgress?: boolean;
       withCredentials?: boolean;
     } = {};
-    if (options.headers && !url.includes('bazaar')) {
+    if (options.headers) {
       ngHttpOptions.headers = new HttpHeaders(options.headers);
     }
     if (options.body) {
@@ -154,6 +146,7 @@ export class Las2peerService {
 
     return this.http
       .request(options.method, url, ngHttpOptions)
+      .pipe(share())
       .toPromise();
   }
 
@@ -187,22 +180,10 @@ export class Las2peerService {
     const sub = JSON.parse(localStorage.getItem('profile'))?.sub;
     const token = localStorage.getItem('access_token');
     if (username) {
-      options = merge(
-        {
-          headers: {
-            Authorization: 'Basic ' + btoa(username + ':' + sub),
-            access_token: token,
-          },
-        },
-        options,
-      );
+      options.headers.Authorization =
+        'Basic ' + btoa(username + ':' + sub);
+      options.headers.access_token = token;
     }
-
-    // if (!environment.production) {
-    //   this.logger.debug(
-    //     'Fetching from ' + url //+ ' with options ' + JSON.stringify(options)
-    //   );
-    // }
 
     const ngHttpOptions: {
       body?: any;

--- a/src/app/services/las2peer.service.ts
+++ b/src/app/services/las2peer.service.ts
@@ -699,7 +699,7 @@ export class Las2peerService {
         `?format=${format}`,
     );
     const requestBody = {
-      cache: false,
+      cache: true,
       dbkey: 'las2peermon',
       height: '200px',
       width: '300px',
@@ -707,7 +707,7 @@ export class Las2peerService {
       query,
       queryparams: queryParams,
       title: '',
-      save: false,
+      save: true,
     };
     const profile = JSON.parse(localStorage.getItem('profile'));
     let authorHeader;
@@ -738,7 +738,7 @@ export class Las2peerService {
       this.QUERY_VISUALIZATION_VISUALIZE_QUERY_PATH,
     );
     const requestBody = {
-      cache: false,
+      cache: true,
       dbkey: 'las2peermon',
       height: '200px',
       width: '300px',
@@ -746,7 +746,7 @@ export class Las2peerService {
       query,
       queryparams: queryParams,
       title: '',
-      save: false,
+      save: true,
     };
     const profile = JSON.parse(localStorage.getItem('profile'));
     let authorHeader;

--- a/src/app/services/las2peer.service.ts
+++ b/src/app/services/las2peer.service.ts
@@ -254,6 +254,16 @@ export class Las2peerService {
     return this.makeRequestAndObserve(url);
   }
 
+  addGroup(groupName: string) {
+    const url = Las2peerService.joinAbsoluteUrlPath(
+      environment.las2peerWebConnectorUrl,
+      this.CONTACT_SERVICE_PATH,
+      this.CONTACT_GROUPS_PATH,
+      groupName,
+    );
+    return this.makeRequestAndObserve(url);
+  }
+
   fetchServicesFromMobSOSAndObserve() {
     const url = Las2peerService.joinAbsoluteUrlPath(
       environment.las2peerWebConnectorUrl,

--- a/src/app/services/store.actions.ts
+++ b/src/app/services/store.actions.ts
@@ -1,7 +1,7 @@
 import { createAction, props } from '@ngrx/store';
 
 import { Measure } from '../models/measure.model';
-import { ReqbazProject } from '../models/reqbaz.model';
+import { ReqbazProject, Requirement } from '../models/reqbaz.model';
 import { ServiceInformation } from '../models/service.model';
 import { SuccessFactor } from '../models/success.model';
 import { User, UserRole } from '../models/user.model';
@@ -48,6 +48,7 @@ enum StoreActions {
   REMOVE_VISUALIZATION_DATA = ' Removes visualization data for a given query',
   ADD_REQUIREMENTS_BAZAR_PROJECT = 'add a requirement bazar project to the success model',
   REMOVE_REQUIREMENTS_BAZAR_PROJECT = 'remove a requirement bazar project from the success model',
+  STORE_REQUIREMENTS = 'Store the requirements for the current req bazar project',
   SET_NUMBER_OF_REQUIREMENTS = 'set the number of requirements for the current project',
 }
 
@@ -117,6 +118,12 @@ export const removeReqBazarProject = createAction(
   StoreActions.REMOVE_REQUIREMENTS_BAZAR_PROJECT,
   props<{
     id: number;
+  }>(),
+);
+export const storeRequirements = createAction(
+  StoreActions.STORE_REQUIREMENTS,
+  props<{
+    requirements: Requirement[];
   }>(),
 );
 

--- a/src/app/services/store.actions.ts
+++ b/src/app/services/store.actions.ts
@@ -244,7 +244,7 @@ export const storeUser = createAction(
 
 export const storeVisualizationData = createAction(
   StoreActions.STORE_VISUALIZATION_DATA,
-  props<{ data: any; query: string; error: any }>(),
+  props<{ data?: any; query?: string; error?: any }>(),
 );
 
 export const storeCatalog = createAction(

--- a/src/app/services/store.actions.ts
+++ b/src/app/services/store.actions.ts
@@ -1,4 +1,5 @@
 import { createAction, props } from '@ngrx/store';
+import { GroupInformation } from '../models/community.model';
 
 import { Measure } from '../models/measure.model';
 import { ReqbazProject, Requirement } from '../models/reqbaz.model';
@@ -7,30 +8,27 @@ import { SuccessFactor } from '../models/success.model';
 import { User, UserRole } from '../models/user.model';
 import { CommunityWorkspace } from '../models/workspace.model';
 
-enum FetchActions {
+export enum HttpActions {
   FETCH_SERVICES = 'Fetch services from the network',
   FETCH_GROUPS = 'fetch groups from the network',
   FETCH_SERVICE_MESSAGE_DESCRIPTION = 'fetch service descriptions for a service from the network ',
   FETCH_MEASURE_CATALOG_FOR_GROUP = 'fetch measure catalog for current Group',
   FETCH_SUCCESS_MODEL_FOR_GROUP_AND_SERVICE = 'fetch success model for current Group and current service',
   FETCH_VISUALIZATION_DATA = 'fetch visualization data from the qvs for a given sql query',
-}
-
-export enum PostActions {
   SAVE_MODEL_AND_CATALOG = 'send an update to the server for both model and catalog',
   SAVE_CATALOG = 'save catalog on the server',
   SAVE_MODEL = 'save model on the server',
-  SUCCESS_RESPONSE = 'response was successfully',
-  FAILURE_RESPONSE = 'response was not successfully',
   SAVE_CATALOG_SUCCESS = 'successfully saved the catalog on the server',
+  ADD_GROUP = 'adds a new group',
 }
 
-enum StoreActions {
+export enum StoreActions {
   STORE_SERVICE_MESSAGE_DESCRIPTION = 'store the service descriptions for a service from the network',
   STORE_SERVICES = 'store services',
   STORE_GROUPS = 'store groups',
   STORE_USER = 'Store the user',
-  SET_USERNAME = 'Set the username. Called for anonymous users',
+  STORE_GROUP = 'Stores a new group in state',
+  STORE_USERNAME = 'Set the username. Called for anonymous users',
   STORE_MEASURE_CATALOG = 'Store the measure catalog as xml string',
   STORE_SUCCESS_MODEL = 'Store the success model as xml string',
   STORE_VISUALIZATION_DATA = 'Store visualization data from the qvs',
@@ -52,7 +50,7 @@ enum StoreActions {
   SET_NUMBER_OF_REQUIREMENTS = 'set the number of requirements for the current project',
 }
 
-enum StateActions {
+export enum StateActions {
   SET_GROUP = 'set current group',
   TRANSFER_MISSING_GROUPS_TO_MOBSOS = 'transfer groups from the contact service which are not known to mobsos to mobsos',
   SET_SERVICE = 'set the current service',
@@ -65,23 +63,24 @@ enum StateActions {
   DECREMENT_LOADING = 'Decrease the number of current http calls',
   TOGGLE_EXPERT_MODE = 'Toggle the expert mode for raw edit of success model and measure catalog',
   INITIALIZE_STATE = 'Initializes the state of the application. This action should only be called once.',
+
+  SUCCESS_RESPONSE = 'response was successfully',
+  FAILURE_RESPONSE = 'response was not successfully',
 }
 
 // fetching
-export const fetchServices = createAction(
-  FetchActions.FETCH_SERVICES,
-);
-export const fetchGroups = createAction(FetchActions.FETCH_GROUPS);
+export const fetchServices = createAction(HttpActions.FETCH_SERVICES);
+export const fetchGroups = createAction(HttpActions.FETCH_GROUPS);
 export const fetchVisualizationData = createAction(
-  FetchActions.FETCH_VISUALIZATION_DATA,
+  HttpActions.FETCH_VISUALIZATION_DATA,
   props<{ query: string; queryParams: string[] }>(),
 );
 export const fetchMeasureCatalog = createAction(
-  FetchActions.FETCH_MEASURE_CATALOG_FOR_GROUP,
+  HttpActions.FETCH_MEASURE_CATALOG_FOR_GROUP,
   props<{ groupId: string }>(),
 );
 export const fetchSuccessModel = createAction(
-  FetchActions.FETCH_SUCCESS_MODEL_FOR_GROUP_AND_SERVICE,
+  HttpActions.FETCH_SUCCESS_MODEL_FOR_GROUP_AND_SERVICE,
   props<{ groupId; serviceName }>(),
 );
 
@@ -114,6 +113,14 @@ export const addReqBazarProject = createAction(
   }>(),
 );
 
+export const addGroup = createAction(
+  HttpActions.ADD_GROUP,
+  props<{ groupName: string }>(),
+);
+export const storeGroup = createAction(
+  StoreActions.STORE_GROUP,
+  props<{ group: GroupInformation }>(),
+);
 export const removeReqBazarProject = createAction(
   StoreActions.REMOVE_REQUIREMENTS_BAZAR_PROJECT,
   props<{
@@ -180,11 +187,11 @@ export const removeMeasure = createAction(
 );
 
 export const saveModelAndCatalog = createAction(
-  PostActions.SAVE_MODEL_AND_CATALOG,
+  HttpActions.SAVE_MODEL_AND_CATALOG,
 );
 
 export const saveModel = createAction(
-  PostActions.SAVE_MODEL,
+  HttpActions.SAVE_MODEL,
   props<{ xml: string }>(),
 );
 
@@ -194,7 +201,7 @@ export const transferMissingGroupsToMobSOS = createAction(
 );
 
 export const saveCatalog = createAction(
-  PostActions.SAVE_CATALOG,
+  HttpActions.SAVE_CATALOG,
   props<{ xml: string }>(),
 );
 
@@ -267,7 +274,7 @@ export const joinWorkSpace = createAction(
 );
 
 export const setUserName = createAction(
-  StoreActions.SET_USERNAME,
+  StoreActions.STORE_USERNAME,
   props<{ username: string }>(),
 );
 
@@ -288,13 +295,13 @@ export const toggleExpertMode = createAction(
 
 // http results
 export const successResponse = createAction(
-  PostActions.SUCCESS_RESPONSE,
+  StateActions.SUCCESS_RESPONSE,
 );
 export const saveCatalogSuccess = createAction(
-  PostActions.SAVE_CATALOG_SUCCESS,
+  HttpActions.SAVE_CATALOG_SUCCESS,
 );
 export const failureResponse = createAction(
-  PostActions.FAILURE_RESPONSE,
+  StateActions.FAILURE_RESPONSE,
   props<{ reason: Error }>(),
 );
 

--- a/src/app/services/store.actions.ts
+++ b/src/app/services/store.actions.ts
@@ -48,6 +48,7 @@ enum StoreActions {
   REMOVE_VISUALIZATION_DATA = ' Removes visualization data for a given query',
   ADD_REQUIREMENTS_BAZAR_PROJECT = 'add a requirement bazar project to the success model',
   REMOVE_REQUIREMENTS_BAZAR_PROJECT = 'remove a requirement bazar project from the success model',
+  SET_NUMBER_OF_REQUIREMENTS = 'set the number of requirements for the current project',
 }
 
 enum StateActions {
@@ -116,6 +117,13 @@ export const removeReqBazarProject = createAction(
   StoreActions.REMOVE_REQUIREMENTS_BAZAR_PROJECT,
   props<{
     id: number;
+  }>(),
+);
+
+export const setNumberOfRequirements = createAction(
+  StoreActions.SET_NUMBER_OF_REQUIREMENTS,
+  props<{
+    n: number;
   }>(),
 );
 

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -283,13 +283,14 @@ export class StateEffects {
       ofType(Action.transferMissingGroupsToMobSOS),
       switchMap((action) => {
         if (action.groupsFromContactService) {
-          const missingGroups =
-            action.groupsFromContactService.filter(
-              (group) =>
-                !action.groupsFromMobSOS?.find(
-                  (g) => g.name === group.name,
-                ),
-            );
+          const missingGroups = Object.values(
+            action.groupsFromContactService,
+          )?.filter(
+            (group: GroupInformation) =>
+              !action.groupsFromMobSOS?.find(
+                (g) => g.name === group.name,
+              ),
+          );
           return this.l2p
             .saveGroupsToMobSOS(missingGroups)
             .pipe(map(() => Action.successResponse()));

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -62,21 +62,21 @@ export class StateEffects {
               return of(undefined);
             }),
           ),
-          this.l2p.fetchServicesFromMobSOSAndObserve().pipe(
-            catchError((err) => {
-              this.logger.error(
-                'Could not fetch services from service MobSOS:' +
-                  JSON.stringify(err),
-              );
+          // this.l2p.fetchServicesFromMobSOSAndObserve().pipe(
+          //   catchError((err) => {
+          //     this.logger.error(
+          //       'Could not fetch services from service MobSOS:' +
+          //         JSON.stringify(err),
+          //     );
 
-              return of(undefined);
-            }),
-          ),
+          //     return of(undefined);
+          //   }),
+          // ),
         ]).pipe(
-          map(([servicesFromL2P, servicesFromMobSOS]) =>
+          map(([servicesFromL2P]) =>
             Action.storeServices({
               servicesFromL2P,
-              servicesFromMobSOS,
+              servicesFromMobSOS: undefined,
             }),
           ),
         ),

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -143,7 +143,7 @@ export class StateEffects {
       ofType(Action.setGroup),
       filter(({ groupId }) => !!groupId),
       tap(({ groupId }) => {
-        this.workspaceService.startSynchronizingWorkspace(groupId);
+        this.workspaceService.syncWithCommunnityWorkspace(groupId);
         this.ngrxStore.dispatch(fetchMeasureCatalog({ groupId }));
       }),
       switchMap(() => of(Action.success())),

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -43,7 +43,7 @@ export class StateEffects {
     private workspaceService: WorkspaceService,
   ) {}
 
-  // static visualizationCalls = {};
+  static visualizationCalls = {};
 
   fetchServices$ = createEffect(() =>
     this.actions$.pipe(
@@ -345,23 +345,21 @@ export class StateEffects {
         const dataForQuery = data[query];
 
         if (
-          // !Object.keys(StateEffects.visualizationCalls).includes(
-          //   query,
-          // ) &&
+          !Object.keys(StateEffects.visualizationCalls).includes(
+            query,
+          ) &&
           shouldFetch(dataForQuery)
         ) {
-          // StateEffects.visualizationCalls[query] =
-          //   dataForQuery?.fetchDate;
-          // console.log(
-          //   Object.keys(StateEffects.visualizationCalls).length,
-          // );
+          StateEffects.visualizationCalls[query] =
+            dataForQuery?.fetchDate;
+
           return this.l2p
             .fetchVisualizationData(query, queryParams)
             .pipe(
-              // tap((data) => {
-              //   if (data)
-              //     delete StateEffects.visualizationCalls[query];
-              // }),
+              tap((data) => {
+                if (data)
+                  delete StateEffects.visualizationCalls[query];
+              }),
               map((vdata) =>
                 Action.storeVisualizationData({
                   data: vdata,
@@ -554,7 +552,7 @@ function shouldFetch(dataForQuery: VData): boolean {
   if (dataForQuery?.data && dataForQuery?.fetchDate) {
     // data was fetched beforehand: now check if data is not too old
     if (
-      Date.now() - dataForQuery.fetchDate.getTime() >
+      Date.now() - Date.parse(dataForQuery.fetchDate) >
       REFETCH_INTERVAL
     ) {
       // data older than fetch interval
@@ -569,7 +567,7 @@ function shouldFetch(dataForQuery: VData): boolean {
     // the query had led to an error
     // in this case we want to  refetch from the server in a shorter interval of 5 minutes
     if (
-      Date.now() - dataForQuery.fetchDate.getTime() >
+      Date.now() - Date.parse(dataForQuery.fetchDate) >
       5 * ONE_MINUTE_IN_MS
     ) {
       if (!status) {

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -19,6 +19,7 @@ import { GroupInformation } from '../models/community.model';
 import { VData } from '../models/visualization.model';
 import { Las2peerService } from './las2peer.service';
 import * as Action from './store.actions';
+import { fetchMeasureCatalog } from './store.actions';
 import {
   _SELECTED_GROUP_ID,
   SELECTED_SERVICE,
@@ -103,26 +104,26 @@ export class StateEffects {
               return of(undefined);
             }),
           ),
-          this.l2p.fetchMobSOSGroupsAndObserve().pipe(
-            catchError((err) => {
-              this.logger.error(
-                'Could not fetch groups from service MobSOS:' +
-                  JSON.stringify(err),
-              );
-              return of(undefined);
-            }),
-          ),
+          // this.l2p.fetchMobSOSGroupsAndObserve().pipe(
+          //   catchError((err) => {
+          //     this.logger.error(
+          //       'Could not fetch groups from service MobSOS:' +
+          //         JSON.stringify(err),
+          //     );
+          //     return of(undefined);
+          //   }),
+          // ),
         ]).pipe(
-          tap(([groupsFromContactService, groupsFromMobSOS]) =>
+          tap(([groupsFromContactService]) =>
             Action.transferMissingGroupsToMobSOS({
               groupsFromContactService,
-              groupsFromMobSOS,
+              groupsFromMobSOS: null,
             }),
           ),
-          map(([groupsFromContactService, groupsFromMobSOS]) =>
+          map(([groupsFromContactService]) =>
             Action.storeGroups({
               groupsFromContactService,
-              groupsFromMobSOS,
+              groupsFromMobSOS: null,
             }),
           ),
         ),
@@ -141,10 +142,9 @@ export class StateEffects {
       filter(({ groupId }) => !!groupId),
       tap(({ groupId }) => {
         this.workspaceService.startSynchronizingWorkspace(groupId);
+        this.ngrxStore.dispatch(fetchMeasureCatalog({ groupId }));
       }),
-      switchMap(({ groupId }) =>
-        of(Action.fetchMeasureCatalog({ groupId })),
-      ),
+      switchMap(() => of(Action.success())),
       catchError((err) => {
         console.error(err);
         return of(Action.failure());

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -30,6 +30,7 @@ import {
   WORKSPACE_MODEL_XML,
   SUCCESS_MODEL_FROM_NETWORK,
   MEASURE_CATALOG_FROM_NETWORK,
+  VISUALIZATION_DATA_FROM_QVS,
 } from './store.selectors';
 import { WorkspaceService } from './workspace.service';
 
@@ -89,7 +90,7 @@ export class StateEffects {
   fetchGroups$ = createEffect(() =>
     this.actions$.pipe(
       ofType(Action.fetchGroups),
-      switchMap(() =>
+      mergeMap(() =>
         forkJoin([
           this.l2p.fetchContactServiceGroupsAndObserve().pipe(
             catchError((err) => {
@@ -463,7 +464,7 @@ export class StateEffects {
         this.ngrxStore.select(MEASURE_CATALOG_FROM_NETWORK),
         this.ngrxStore.select(SELECTED_SERVICE),
         this.ngrxStore.select(_USER),
-        this.ngrxStore.select(VISUALIZATION_DATA),
+        this.ngrxStore.select(VISUALIZATION_DATA_FROM_QVS),
       ),
       switchMap(([action, model, catalog, service, user, vdata]) =>
         this.workspaceService

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -44,6 +44,8 @@ export class StateEffects {
     private workspaceService: WorkspaceService,
   ) {}
 
+  // hardcoded map of current visualization calls to prevent sending a POST request multiple times
+  // I will leave it here for the demo but should not be necessary. Removal should not cause any problems
   static visualizationCalls = {};
 
   fetchServices$ = createEffect(() =>
@@ -368,8 +370,8 @@ export class StateEffects {
           return this.l2p
             .fetchVisualizationData(query, queryParams)
             .pipe(
-              tap((data) => {
-                if (data)
+              tap((success) => {
+                if (success)
                   delete StateEffects.visualizationCalls[query];
               }),
               map((vdata) =>

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -394,6 +394,30 @@ export class StateEffects {
     ),
   );
 
+  addGroup$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(Action.addGroup),
+      mergeMap(({ groupName }) =>
+        this.l2p.addGroup(groupName).pipe(
+          map((id: string) =>
+            id
+              ? Action.storeGroup({
+                  group: { id, name: groupName, member: true },
+                })
+              : Action.failureResponse,
+          ),
+          catchError((err) => {
+            return of(Action.storeSuccessModel({ xml: null }));
+          }),
+        ),
+      ),
+      catchError((err) => {
+        return of(Action.storeSuccessModel({ xml: null }));
+      }),
+      share(),
+    ),
+  );
+
   joinCommunityWorkSpace$ = createEffect(() =>
     this.actions$.pipe(
       ofType(Action.joinWorkSpace),

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -344,7 +344,7 @@ export class StateEffects {
     this.actions$.pipe(
       ofType(Action.fetchVisualizationData),
       withLatestFrom(this.ngrxStore.select(VISUALIZATION_DATA)),
-      switchMap(([{ query, queryParams }, data]) => {
+      mergeMap(([{ query, queryParams }, data]) => {
         const dataForQuery = data[query];
         if (shouldFetch(dataForQuery)) {
           return this.l2p

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -223,7 +223,18 @@ export class StateEffects {
       switchMap(([action, [measureCatalogXML, groupId]]) =>
         this.l2p
           .saveMeasureCatalogAndObserve(groupId, measureCatalogXML)
-          .pipe(map(() => Action.saveCatalogSuccess())),
+          .pipe(
+            tap(() =>
+              this.ngrxStore.dispatch(
+                Action.storeCatalog({ xml: measureCatalogXML }),
+              ),
+            ),
+            map(() => Action.saveCatalogSuccess()),
+            catchError((err) => {
+              console.error(err);
+              return of(Action.failureResponse(err));
+            }),
+          ),
       ),
       catchError((err) => {
         console.error(err);

--- a/src/app/services/store.effects.ts
+++ b/src/app/services/store.effects.ts
@@ -437,7 +437,7 @@ export class StateEffects {
         this.ngrxStore.select(_USER),
         this.ngrxStore.select(VISUALIZATION_DATA),
       ),
-      exhaustMap(([action, model, catalog, service, user, vdata]) =>
+      switchMap(([action, model, catalog, service, user, vdata]) =>
         this.workspaceService
           .syncWithCommunnityWorkspace(action.groupId)
           .pipe(

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -305,21 +305,25 @@ function removeReqBazarProject(state: AppState) {
 
 function updateVisualizationData(
   currentVisualizationData: VisualizationData,
-  props: { data: any[][]; query: string; error: HttpErrorResponse },
+  props: {
+    data?: any[][];
+    query?: string;
+    error?: HttpErrorResponse;
+  },
 ) {
-  if (!props.query || (!props.data && !props.error)) {
+  if (!props.query || props?.error?.status < 200) {
     return currentVisualizationData;
   }
-
-  if (props.error?.status >= 400 && props.error?.status < 500) {
-    currentVisualizationData[props.query] = {
-      ...currentVisualizationData[props.query],
-      error: props.error,
-    };
-  } else {
+  if (props.data) {
+    // overwrite existing data
     currentVisualizationData[props.query] = {
       data: props.data,
       fetchDate: new Date(),
+      error: null,
+    };
+  } else if (props.error) {
+    currentVisualizationData[props.query] = {
+      ...currentVisualizationData[props.query],
       error: props.error,
     };
   }

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -443,6 +443,7 @@ function mergeGroupData(
 ) {
   // mark all these groups as groups the current user is a member of
   if (groupsFromContactService) {
+    groups = {};
     for (const groupID of Object.keys(groupsFromContactService)) {
       const groupName = groupsFromContactService[groupID];
       groups[groupID] = {
@@ -751,34 +752,34 @@ function getSelectedService(state: AppState) {
   if (!state.services || !state.selectedServiceName) return undefined;
   return state.services[state.selectedServiceName];
 }
-function addVisitor(
-  communityWorkspace: CommunityWorkspace,
-  username: string,
-  owner: string,
-  serviceName: string,
-  role: UserRole,
-): CommunityWorkspace {
-  const copy = cloneDeep(communityWorkspace); // copy workspace first
-  const userWorkspace = copy[owner];
-  if (!userWorkspace) return communityWorkspace;
-  const appWorkspace: ApplicationWorkspace =
-    userWorkspace[serviceName];
-  if (!appWorkspace) return communityWorkspace;
-  let visitor = appWorkspace.visitors?.find(
-    (v) => v.username === username,
-  );
-  if (role === UserRole.LURKER) {
-    if (visitor) {
-      username =
-        username + ' (guest ' + appWorkspace.visitors.length + ')';
-    }
-    appWorkspace.visitors.push(new Visitor(username, role));
-  } else if (!visitor) {
-    visitor = new Visitor(username, role);
-    appWorkspace.visitors.push(visitor);
-  }
-  return copy;
-}
+// function addVisitor(
+//   communityWorkspace: CommunityWorkspace,
+//   username: string,
+//   owner: string,
+//   serviceName: string,
+//   role: UserRole,
+// ): CommunityWorkspace {
+//   const copy = cloneDeep(communityWorkspace); // copy workspace first
+//   const userWorkspace = copy[owner];
+//   if (!userWorkspace) return communityWorkspace;
+//   const appWorkspace: ApplicationWorkspace =
+//     userWorkspace[serviceName];
+//   if (!appWorkspace) return communityWorkspace;
+//   let visitor = appWorkspace.visitors?.find(
+//     (v) => v.username === username,
+//   );
+//   if (role === UserRole.LURKER) {
+//     if (visitor) {
+//       username =
+//         username + ' (guest ' + appWorkspace.visitors.length + ')';
+//     }
+//     appWorkspace.visitors.push(new Visitor(username, role));
+//   } else if (!visitor) {
+//     visitor = new Visitor(username, role);
+//     appWorkspace.visitors.push(visitor);
+//   }
+//   return copy;
+// }
 
 function getWorkspaceByUserAndService(
   communityWorkspace: CommunityWorkspace,

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -14,6 +14,10 @@ import { UserRole, Visitor } from '../models/user.model';
 import { HttpErrorResponse } from '@angular/common/http';
 import { isEmpty } from 'lodash-es';
 import { ReqbazProject } from '../models/reqbaz.model';
+import {
+  GroupCollection,
+  GroupInformation,
+} from '../models/community.model';
 
 export const initialState: AppState = INITIAL_APP_STATE;
 
@@ -142,6 +146,10 @@ const _Reducer = createReducer(
   on(Actions.storeRequirements, (state, { requirements }) => ({
     ...state,
     requirements,
+  })),
+  on(Actions.storeGroup, (state, { group }) => ({
+    ...state,
+    groups: addGroup(group, state.groups),
   })),
   on(Actions.incrementLoading, (state) => ({
     ...state,
@@ -792,5 +800,13 @@ function removeVisualizationData(
 ): VisualizationData {
   const copy = { ...visualizationData };
   delete copy[query];
+  return copy;
+}
+function addGroup(group: GroupInformation, groups: GroupCollection) {
+  if (!group?.id) {
+    return groups;
+  }
+  const copy = cloneDeep(groups);
+  copy[group.id] = group;
   return copy;
 }

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -321,10 +321,11 @@ function updateVisualizationData(
       fetchDate: new Date(),
       error: null,
     };
-  } else if (props.error) {
+  } else {
     currentVisualizationData[props.query] = {
       ...currentVisualizationData[props.query],
-      error: props.error,
+      error: props?.error,
+      fetchDate: new Date(),
     };
   }
 

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -318,14 +318,14 @@ function updateVisualizationData(
     // overwrite existing data
     currentVisualizationData[props.query] = {
       data: props.data,
-      fetchDate: new Date(),
+      fetchDate: new Date().toISOString(),
       error: null,
     };
   } else {
     currentVisualizationData[props.query] = {
       ...currentVisualizationData[props.query],
       error: props?.error,
-      fetchDate: new Date(),
+      fetchDate: new Date().toISOString(),
     };
   }
 

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -77,6 +77,10 @@ const _Reducer = createReducer(
     ...state,
     expertMode: !state.expertMode,
   })),
+  on(Actions.setNumberOfRequirements, (state, { n }) => ({
+    ...state,
+    numberOfRequirements: n,
+  })),
   on(Actions.storeUser, (state, { user }) => ({
     ...state,
     user: { ...user, signedIn: !!user },

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -150,6 +150,7 @@ const _Reducer = createReducer(
   on(Actions.storeGroup, (state, { group }) => ({
     ...state,
     groups: addGroup(group, state.groups),
+    selectedGroupId: group.id,
   })),
   on(Actions.incrementLoading, (state) => ({
     ...state,

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -198,7 +198,7 @@ const _Reducer = createReducer(
   })),
   on(Actions.addMeasureToCatalog, (state, props) => ({
     ...state,
-    communityWorkspace: addMeasureToMeasures(
+    communityWorkspace: addMeasureToMeasureCatalog(
       props.measure,
       state.communityWorkspace,
       state.currentWorkSpaceOwner,
@@ -618,7 +618,7 @@ function editFactorInDimension(
   return copy;
 }
 
-function addMeasureToMeasures(
+function addMeasureToMeasureCatalog(
   measure: Measure,
   communityWorkspace: CommunityWorkspace,
   owner: string,
@@ -630,7 +630,7 @@ function addMeasureToMeasures(
     owner,
     serviceName,
   );
-  const measureMap = appWorkspace.catalog;
+  const measureMap = appWorkspace.catalog?.measures;
   measureMap[measure.name] = measure;
   return copy;
 }

--- a/src/app/services/store.reducer.ts
+++ b/src/app/services/store.reducer.ts
@@ -139,7 +139,10 @@ const _Reducer = createReducer(
     ...state,
     communityWorkspace: removeReqBazarProject(state),
   })),
-
+  on(Actions.storeRequirements, (state, { requirements }) => ({
+    ...state,
+    requirements,
+  })),
   on(Actions.incrementLoading, (state) => ({
     ...state,
     currentNumberOfHttpCalls: state.currentNumberOfHttpCalls + 1,

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -194,7 +194,9 @@ export const SUCCESS_MODEL = createSelector(
   SUCCESS_MODEL_FROM_NETWORK,
   SUCCESS_MODEL_FROM_WORKSPACE,
   (editMode, successModelFromNetwork, successModelInWorkspace) =>
-    editMode ? successModelInWorkspace : successModelFromNetwork,
+    editMode && successModelInWorkspace
+      ? successModelInWorkspace
+      : successModelFromNetwork,
 );
 
 export const DIMENSIONS_IN_MODEL = createSelector(
@@ -250,7 +252,7 @@ export const MEASURE_CATALOG = createSelector(
     measureCatalogFromNetwork,
     measureCatalogFromWorkspace,
   ) =>
-    editMode
+    editMode && measureCatalogFromWorkspace
       ? measureCatalogFromWorkspace
       : measureCatalogFromNetwork,
 );

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -252,7 +252,7 @@ export const MEASURE_CATALOG = createSelector(
     measureCatalogFromNetwork,
     measureCatalogFromWorkspace,
   ) =>
-    editMode && measureCatalogFromWorkspace
+    editMode
       ? measureCatalogFromWorkspace
       : measureCatalogFromNetwork,
 );

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -287,7 +287,7 @@ export const WORKSPACE_CATALOG_XML = createSelector(
 );
 
 // VISUALIZATION_DATA
-const VISUALIZATION_DATA_FROM_QVS = (state: StoreState) =>
+export const VISUALIZATION_DATA_FROM_QVS = (state: StoreState) =>
   state.Reducer?.visualizationData;
 
 export const VISUALIZATION_DATA_FROM_WORKSPACE = createSelector(
@@ -304,9 +304,14 @@ export const VISUALIZATION_DATA = createSelector(
 );
 
 export const VISUALIZATION_DATA_FOR_QUERY = createSelector(
-  VISUALIZATION_DATA,
-  (vdata, queryString: string) =>
-    vdata ? vdata[queryString] : undefined,
+  VISUALIZATION_DATA_FROM_QVS,
+  VISUALIZATION_DATA_FROM_WORKSPACE,
+  (workspacedata, qvsdata, queryString: string) =>
+    workspacedata && workspacedata[queryString]
+      ? workspacedata[queryString]
+      : qvsdata
+      ? qvsdata[queryString]
+      : undefined,
 );
 
 export const MODEL_AND_CATALOG_LOADED = createSelector(

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -21,6 +21,9 @@ import {
 export const HTTP_CALL_IS_LOADING = (state: StoreState) =>
   state.Reducer?.currentNumberOfHttpCalls > 0;
 
+export const NUMBER_OF_REQUIREMENTS = (state: StoreState) =>
+  state.Reducer?.numberOfRequirements;
+
 export const _EDIT_MODE = (state: StoreState) =>
   state.Reducer?.editMode;
 

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -128,14 +128,10 @@ export const WORKSPACE_OWNER = createSelector(
 
 export const ALL_WORKSPACES_FOR_SELECTED_SERVICE_EXCEPT_ACTIVE =
   createSelector(
-    _COMMUNITY_WORKSPACE,
-    _SELECTED_SERVICE_NAME,
+    ALL_WORKSPACES_FOR_SELECTED_SERVICE,
     WORKSPACE_OWNER,
-    (communityWorkspace, selectedServiceName, owner) =>
-      getAllWorkspacesForService(
-        communityWorkspace,
-        selectedServiceName,
-      )?.filter(
+    (workspaces, owner) =>
+      workspaces?.filter(
         (workspace: ApplicationWorkspace) =>
           workspace?.createdBy !== owner,
       ),
@@ -143,7 +139,10 @@ export const ALL_WORKSPACES_FOR_SELECTED_SERVICE_EXCEPT_ACTIVE =
 
 export const VISITORS = createSelector(
   APPLICATION_WORKSPACE,
-  (workspace) => workspace?.visitors,
+  (workspace) =>
+    workspace?.visitors.sort((a, b) =>
+      a.username?.localeCompare(b.username),
+    ),
 );
 
 export const VISITORS_EXCEPT_USER = createSelector(
@@ -449,7 +448,9 @@ function getAllWorkspacesForService(
       result.push(userWorkspace[serviceName] as ApplicationWorkspace);
     }
   }
-  return result as ApplicationWorkspace[];
+  return (result as ApplicationWorkspace[])?.sort((a, b) =>
+    a.createdBy?.localeCompare(b.createdBy),
+  );
 }
 
 /**

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -64,11 +64,11 @@ export const GROUPS = (state: StoreState) =>
     : undefined;
 
 export const USER_GROUPS = createSelector(GROUPS, (groups) =>
-  groups.filter((g) => g.member),
+  groups?.filter((g) => g.member),
 );
 
 export const FOREIGN_GROUPS = createSelector(GROUPS, (groups) =>
-  groups.filter((g) => !g.member),
+  groups?.filter((g) => !g.member),
 );
 
 export const SELECTED_GROUP = createSelector(

--- a/src/app/services/store.selectors.ts
+++ b/src/app/services/store.selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@ngrx/store';
+import { create } from 'domain';
 import {
   GroupCollection,
   GroupInformation,
@@ -62,11 +63,13 @@ export const GROUPS = (state: StoreState) =>
       )
     : undefined;
 
-export const USER_GROUPS = (state: StoreState) =>
-  _userGroups(state.Reducer?.groups);
+export const USER_GROUPS = createSelector(GROUPS, (groups) =>
+  groups.filter((g) => g.member),
+);
 
-export const FOREIGN_GROUPS = (state: StoreState) =>
-  _foreignGroups(state.Reducer?.groups);
+export const FOREIGN_GROUPS = createSelector(GROUPS, (groups) =>
+  groups.filter((g) => !g.member),
+);
 
 export const SELECTED_GROUP = createSelector(
   _SELECTED_GROUP_ID,

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -170,14 +170,16 @@ export class WorkspaceService {
 
     this.startSynchronizingWorkspace(groupId);
     // get the current workspace state from yjs
-    const communityWorkspace =
+    let communityWorkspace =
       this.getCurrentCommunityWorkspaceFromYJS(groupId);
 
     setTimeout(() => {
+      communityWorkspace =
+        this.getCurrentCommunityWorkspaceFromYJS(groupId);
       if (communityWorkspace) {
         this.syncDone$.next(true);
       }
-    }, ONE_MINUTE_IN_MS);
+    }, 500);
 
     this.communityWorkspace$.next(communityWorkspace);
     return this.syncDone$.asObservable().pipe(
@@ -319,7 +321,7 @@ export class WorkspaceService {
     if (vdata) {
       for (const [query, value] of Object.entries(vdata)) {
         if (value.data && value?.fetchDate) {
-          const workspaceData =
+          let workspaceData =
             currentApplicationWorkspace.visualizationData[query];
           if (
             !workspaceData?.fetchDate ||
@@ -329,8 +331,8 @@ export class WorkspaceService {
             )
           ) {
             // we have more recent data so we add our data
-            workspaceData[query] = {
-              ...workspaceData[query],
+            workspaceData = {
+              ...workspaceData,
               data: value.data,
             };
           }

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -172,9 +172,13 @@ export class WorkspaceService {
     // get the current workspace state from yjs
     const communityWorkspace =
       this.getCurrentCommunityWorkspaceFromYJS(groupId);
-    if (communityWorkspace) {
-      this.syncDone$.next(true);
-    }
+
+    setTimeout(() => {
+      if (communityWorkspace) {
+        this.syncDone$.next(true);
+      }
+    }, ONE_MINUTE_IN_MS);
+
     this.communityWorkspace$.next(communityWorkspace);
     return this.syncDone$.asObservable().pipe(
       timeout(2 * ONE_MINUTE_IN_MS),
@@ -314,13 +318,14 @@ export class WorkspaceService {
     }
     if (vdata) {
       for (const [query, value] of Object.entries(vdata)) {
-        if (value.data) {
+        if (value.data && value?.fetchDate) {
           const workspaceData =
             currentApplicationWorkspace.visualizationData[query];
           if (
+            !workspaceData?.fetchDate ||
             !(
-              workspaceData?.fetchDate.getTime() >
-              value.fetchDate.getTime()
+              Date.parse(workspaceData.fetchDate as string) >
+              Date.parse(value?.fetchDate)
             )
           ) {
             // we have more recent data so we add our data

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -179,7 +179,7 @@ export class WorkspaceService {
       if (communityWorkspace) {
         this.syncDone$.next(true);
       }
-    }, 500);
+    }, 200);
 
     this.communityWorkspace$.next(communityWorkspace);
     return this.syncDone$.asObservable().pipe(
@@ -217,7 +217,7 @@ export class WorkspaceService {
    * This function start synchronizing the workspace for the current community
    * @param groupId groupid for the community
    */
-  startSynchronizingWorkspace(groupId: string) {
+  private startSynchronizingWorkspace(groupId: string) {
     if (groupId !== this.currentGroupId) {
       if (this.currentGroupId) {
         this.stopSynchronizingWorkspace(this.currentGroupId);

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -312,6 +312,26 @@ export class WorkspaceService {
         'this user has no application workspace for the current service',
       );
     }
+    if (vdata) {
+      for (const [query, value] of Object.entries(vdata)) {
+        if (value.data) {
+          const workspaceData =
+            currentApplicationWorkspace.visualizationData[query];
+          if (
+            !(
+              workspaceData?.fetchDate.getTime() >
+              value.fetchDate.getTime()
+            )
+          ) {
+            // we have more recent data so we add our data
+            workspaceData[query] = {
+              ...workspaceData[query],
+              data: value.data,
+            };
+          }
+        }
+      }
+    }
 
     if (username === owner) {
       currentApplicationWorkspace.catalog = catalog;

--- a/src/app/success-dimension/success-dimension.component.ts
+++ b/src/app/success-dimension/success-dimension.component.ts
@@ -65,23 +65,22 @@ export class SuccessDimensionComponent implements OnInit {
 
   ngOnInit() {}
 
-  openAddFactorDialog() {
+  async openAddFactorDialog() {
     const dialogRef = this.dialog.open(EditFactorDialogComponent, {
       // width: '250px',
       data: { factor: new SuccessFactor('', []) },
     });
 
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this._factors.push(result);
-        this.ngrxStore.dispatch(
-          addFactorToDimension({
-            factor: result,
-            dimensionName: this.name,
-          }),
-        );
-      }
-    });
+    const result = await dialogRef.afterClosed().toPromise();
+    if (result) {
+      this._factors.push(result);
+      this.ngrxStore.dispatch(
+        addFactorToDimension({
+          factor: result,
+          dimensionName: this.name,
+        }),
+      );
+    }
   }
 
   async openRemoveFactorDialog(factorIndex: number) {
@@ -92,11 +91,10 @@ export class SuccessDimensionComponent implements OnInit {
       minWidth: 300,
       data: message,
     });
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.removeFactor(factorIndex);
-      }
-    });
+    const result = dialogRef.afterClosed();
+    if (result) {
+      this.removeFactor(factorIndex);
+    }
   }
 
   private removeFactor(factorIndex: number) {

--- a/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
+++ b/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
@@ -237,9 +237,8 @@
     }}
   </h3>
   <app-success-measure
-    #previewMeasure
+    [preview]="true"
     [measureName]="data.measure.name"
-    [service]="data.service"
   ></app-success-measure>
 </div>
 <div mat-dialog-actions>

--- a/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
+++ b/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
@@ -89,9 +89,6 @@
             | translate
         }} #{{ i + 1 }}"
         [(ngModel)]="query.sql"
-        (ngModelChange)="
-          previewMeasure.rerenderVisualizationComponent()
-        "
       ></textarea>
     </mat-form-field>
   </div>
@@ -152,9 +149,6 @@
         <mat-label>Operand</mat-label>
         <mat-select
           [ngModel]="$any(termPart).name"
-          (ngModelChange)="
-            previewMeasure.rerenderVisualizationComponent()
-          "
           (selectionChange)="onKpiOperandChange($event.value, i)"
         >
           <mat-option
@@ -169,9 +163,6 @@
         <mat-label>Operator</mat-label>
         <mat-select
           [ngModel]="$any(termPart).name"
-          (ngModelChange)="
-            previewMeasure.rerenderVisualizationComponent()
-          "
           (selectionChange)="onKpiOperatorChange($event.value, i)"
         >
           <mat-option
@@ -215,9 +206,6 @@
       <mat-label>Type</mat-label>
       <mat-select
         [(ngModel)]="$any(data.measure.visualization).chartType"
-        (ngModelChange)="
-          previewMeasure.rerenderVisualizationComponent()
-        "
       >
         <mat-option
           *ngFor="let item of chartTypeChoices | keyvalue"
@@ -238,7 +226,7 @@
   </h3>
   <app-success-measure
     [preview]="true"
-    [measureName]="data.measure.name"
+    [measureName]="data.measure?.name"
   ></app-success-measure>
 </div>
 <div mat-dialog-actions>

--- a/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
+++ b/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.html
@@ -1,9 +1,21 @@
-<h1 mat-dialog-title *ngIf="data.create">{{'success-modeling.edit-measure-dialog.title-create'|translate}}</h1>
-<h1 mat-dialog-title *ngIf="!data.create">{{'success-modeling.edit-measure-dialog.title-edit'|translate}}</h1>
+<h1 mat-dialog-title *ngIf="data.create">
+  {{
+    'success-modeling.edit-measure-dialog.title-create' | translate
+  }}
+</h1>
+<h1 mat-dialog-title *ngIf="!data.create">
+  {{ 'success-modeling.edit-measure-dialog.title-edit' | translate }}
+</h1>
 <div mat-dialog-content>
   <mat-form-field>
-    <input matInput placeholder="{{'success-modeling.edit-measure-dialog.name-placeholder'|translate}}"
-           [(ngModel)]="data.measure.name">
+    <input
+      matInput
+      placeholder="{{
+        'success-modeling.edit-measure-dialog.name-placeholder'
+          | translate
+      }}"
+      [(ngModel)]="data.measure.name"
+    />
   </mat-form-field>
 
   <mat-divider></mat-divider>
@@ -17,8 +29,13 @@
         </mat-panel-description>
       </mat-expansion-panel-header>
       <ng-template matExpansionPanelContent>
-        <div *ngFor="let item of data.service.serviceMessageDescriptions | keyvalue">
-          <h2>{{prettifyCustomMessageName(item.key)}}</h2>
+        <div
+          *ngFor="
+            let item of data.service.serviceMessageDescriptions
+              | keyvalue
+          "
+        >
+          <h2>{{ prettifyCustomMessageName(item.key) }}</h2>
           <mat-accordion [multi]="true">
             <mat-expansion-panel [expanded]="false">
               <mat-expansion-panel-header>
@@ -26,7 +43,7 @@
               </mat-expansion-panel-header>
               <ng-template matExpansionPanelContent>
                 <markdown ngPreserveWhitespaces>
-                  {{item.value}}
+                  {{ item.value }}
                 </markdown>
               </ng-template>
             </mat-expansion-panel>
@@ -35,8 +52,14 @@
                 <mat-panel-title>Latest Log Entries</mat-panel-title>
               </mat-expansion-panel-header>
               <ng-template matExpansionPanelContent>
-                <app-sql-table [service]="data.service"
-                               [query]="'SELECT REMARKS,TIME_STAMP,SOURCE_NODE,SOURCE_AGENT FROM MESSAGE WHERE EVENT=&quot'+item.key+'&quot AND SOURCE_AGENT IN $SERVICES$ ORDER BY ID DESC LIMIT 5'">
+                <app-sql-table
+                  [service]="data.service"
+                  [query]="
+                    'SELECT REMARKS,TIME_STAMP,SOURCE_NODE,SOURCE_AGENT FROM MESSAGE WHERE EVENT=&quot' +
+                    item.key +
+                    '&quot AND SOURCE_AGENT IN $SERVICES$ ORDER BY ID DESC LIMIT 5'
+                  "
+                >
                 </app-sql-table>
               </ng-template>
             </mat-expansion-panel>
@@ -48,81 +71,159 @@
 
   <div *ngFor="let query of data.measure.queries; let i = index">
     <mat-form-field>
-      <input matInput
-             placeholder="{{'success-modeling.edit-measure-dialog.query-name-placeholder'|translate}} #{{i + 1}}"
-             [ngModel]="query.name"
-             (change)="onQueryNameChanged($any($event.target).value, i)">
+      <input
+        matInput
+        placeholder="{{
+          'success-modeling.edit-measure-dialog.query-name-placeholder'
+            | translate
+        }} #{{ i + 1 }}"
+        [ngModel]="query.name"
+        (change)="onQueryNameChanged($any($event.target).value, i)"
+      />
     </mat-form-field>
     <mat-form-field>
-      <textarea matInput placeholder="{{'success-modeling.edit-measure-dialog.query-placeholder'|translate}} #{{i +1}}"
-                [(ngModel)]="query.sql" (ngModelChange)="previewMeasure.rerenderVisualizationComponent()"></textarea>
+      <textarea
+        matInput
+        placeholder="{{
+          'success-modeling.edit-measure-dialog.query-placeholder'
+            | translate
+        }} #{{ i + 1 }}"
+        [(ngModel)]="query.sql"
+        (ngModelChange)="
+          previewMeasure.rerenderVisualizationComponent()
+        "
+      ></textarea>
     </mat-form-field>
   </div>
 
   <button mat-button color="primary" (click)="onAddQueryClicked()">
-    {{'success-modeling.edit-measure-dialog.add-query'|translate}}
+    {{ 'success-modeling.edit-measure-dialog.add-query' | translate }}
   </button>
-  <button mat-button color="warn" (click)="onRemoveQueryClicked()" [disabled]="data.measure.queries.length <= 1">
-    {{'success-modeling.edit-measure-dialog.remove-query'|translate}}
+  <button
+    mat-button
+    color="warn"
+    (click)="onRemoveQueryClicked()"
+    [disabled]="data.measure.queries.length <= 1"
+  >
+    {{
+      'success-modeling.edit-measure-dialog.remove-query' | translate
+    }}
   </button>
-
 
   <mat-divider></mat-divider>
   <mat-form-field>
-    <mat-label>{{'success-modeling.edit-measure-dialog.visualization-select'|translate}}</mat-label>
-    <mat-select [ngModel]="data.measure.visualization.type" (selectionChange)="onVisualizationChange($event.value)">
-      <mat-option *ngFor="let item of visualizationChoices | keyvalue" [value]="item.key">
-        {{item.value|translate}}
+    <mat-label>{{
+      'success-modeling.edit-measure-dialog.visualization-select'
+        | translate
+    }}</mat-label>
+    <mat-select
+      [ngModel]="data.measure.visualization.type"
+      (selectionChange)="onVisualizationChange($event.value)"
+    >
+      <mat-option
+        *ngFor="let item of visualizationChoices | keyvalue"
+        [value]="item.key"
+      >
+        {{ item.value | translate }}
       </mat-option>
     </mat-select>
   </mat-form-field>
 
   <mat-form-field *ngIf="data.measure.visualization.type === 'Value'">
-    <input matInput
-           placeholder="{{'success-modeling.edit-measure-dialog.unit-placeholder'|translate}}"
-           [(ngModel)]="$any(data.measure.visualization).unit">
+    <input
+      matInput
+      placeholder="{{
+        'success-modeling.edit-measure-dialog.unit-placeholder'
+          | translate
+      }}"
+      [(ngModel)]="$any(data.measure.visualization).unit"
+    />
   </mat-form-field>
 
   <div *ngIf="data.measure.visualization.type === 'KPI'">
-    <div *ngFor="let termPart of $any(data.measure.visualization).operationsElements; let i=index">
+    <div
+      *ngFor="
+        let termPart of $any(data.measure.visualization)
+          .operationsElements;
+        let i = index
+      "
+    >
       <mat-form-field *ngIf="i % 2 === 0">
         <mat-label>Operand</mat-label>
-        <mat-select [ngModel]="$any(termPart).name"
-                    (ngModelChange)="previewMeasure.rerenderVisualizationComponent()"
-                    (selectionChange)="onKpiOperandChange($event.value, i)">
-          <mat-option *ngFor="let query of data.measure.queries" [value]="query.name">
-            {{query.name}}
+        <mat-select
+          [ngModel]="$any(termPart).name"
+          (ngModelChange)="
+            previewMeasure.rerenderVisualizationComponent()
+          "
+          (selectionChange)="onKpiOperandChange($event.value, i)"
+        >
+          <mat-option
+            *ngFor="let query of data.measure.queries"
+            [value]="query.name"
+          >
+            {{ query.name }}
           </mat-option>
         </mat-select>
       </mat-form-field>
       <mat-form-field *ngIf="i % 2 !== 0">
         <mat-label>Operator</mat-label>
-        <mat-select [ngModel]="$any(termPart).name"
-                    (ngModelChange)="previewMeasure.rerenderVisualizationComponent()"
-                    (selectionChange)="onKpiOperatorChange($event.value, i)">
-          <mat-option *ngFor="let operator of ['+', '-', '*', '/']" [value]="operator">
-            {{operator}}
+        <mat-select
+          [ngModel]="$any(termPart).name"
+          (ngModelChange)="
+            previewMeasure.rerenderVisualizationComponent()
+          "
+          (selectionChange)="onKpiOperatorChange($event.value, i)"
+        >
+          <mat-option
+            *ngFor="let operator of ['+', '-', '*', '/']"
+            [value]="operator"
+          >
+            {{ operator }}
           </mat-option>
         </mat-select>
       </mat-form-field>
     </div>
 
-    <button mat-button color="primary" (click)="onAddOperationClicked()">
-      {{'success-modeling.edit-measure-dialog.add-operation'|translate}}
+    <button
+      mat-button
+      color="primary"
+      (click)="onAddOperationClicked()"
+    >
+      {{
+        'success-modeling.edit-measure-dialog.add-operation'
+          | translate
+      }}
     </button>
-    <button mat-button color="warn" (click)="onRemoveOperationClicked()"
-            [disabled]="$any(data.measure.visualization).operationsElements.length <= 1">
-      {{'success-modeling.edit-measure-dialog.remove-operation'|translate}}
+    <button
+      mat-button
+      color="warn"
+      (click)="onRemoveOperationClicked()"
+      [disabled]="
+        $any(data.measure.visualization).operationsElements.length <=
+        1
+      "
+    >
+      {{
+        'success-modeling.edit-measure-dialog.remove-operation'
+          | translate
+      }}
     </button>
   </div>
 
   <div *ngIf="data.measure.visualization.type === 'Chart'">
     <mat-form-field>
       <mat-label>Type</mat-label>
-      <mat-select [(ngModel)]="$any(data.measure.visualization).chartType"
-                  (ngModelChange)="previewMeasure.rerenderVisualizationComponent()">
-        <mat-option *ngFor="let item of chartTypeChoices | keyvalue" [value]="item.key">
-          {{item.value|translate}}
+      <mat-select
+        [(ngModel)]="$any(data.measure.visualization).chartType"
+        (ngModelChange)="
+          previewMeasure.rerenderVisualizationComponent()
+        "
+      >
+        <mat-option
+          *ngFor="let item of chartTypeChoices | keyvalue"
+          [value]="item.key"
+        >
+          {{ item.value | translate }}
         </mat-option>
       </mat-select>
     </mat-form-field>
@@ -130,11 +231,26 @@
 
   <mat-divider></mat-divider>
 
-  <h3>{{'success-modeling.edit-measure-dialog.preview-title'|translate}}</h3>
-  <app-success-measure #previewMeasure [measure]="data.measure" [service]="data.service"></app-success-measure>
+  <h3>
+    {{
+      'success-modeling.edit-measure-dialog.preview-title' | translate
+    }}
+  </h3>
+  <app-success-measure
+    #previewMeasure
+    [measureName]="data.measure.name"
+    [service]="data.service"
+  ></app-success-measure>
 </div>
 <div mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="data.measure"
-          cdkFocusInitial>{{'shared.elements.save-label'|translate}}</button>
-  <button mat-button [mat-dialog-close]="null">{{'shared.elements.cancel-label'|translate}}</button>
+  <button
+    mat-button
+    [mat-dialog-close]="data.measure"
+    cdkFocusInitial
+  >
+    {{ 'shared.elements.save-label' | translate }}
+  </button>
+  <button mat-button [mat-dialog-close]="null">
+    {{ 'shared.elements.cancel-label' | translate }}
+  </button>
 </div>

--- a/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.ts
+++ b/src/app/success-factor/edit-measure-dialog/edit-measure-dialog.component.ts
@@ -13,6 +13,7 @@ import {
   ValueVisualization,
 } from 'src/app/models/visualization.model';
 import { Query } from 'src/app/models/query.model';
+import { SuccessMeasureComponent } from 'src/app/success-measure/success-measure.component';
 
 export interface DialogData {
   measure: Measure;
@@ -26,7 +27,6 @@ export interface DialogData {
   styleUrls: ['./edit-measure-dialog.component.scss'],
 })
 export class EditMeasureDialogComponent implements OnInit {
-  @ViewChild('previewMeasure') public previewMeasure;
   visualizationChoices = {
     Value: 'success-modeling.edit-measure-dialog.choice-value',
     Chart: 'success-modeling.edit-measure-dialog.choice-chart',
@@ -70,7 +70,6 @@ export class EditMeasureDialogComponent implements OnInit {
     }
     this.data.measure.visualization =
       this.visualizationBuffer[visualizationType];
-    this.previewMeasure.refreshVisualization();
   }
 
   onAddQueryClicked() {
@@ -88,7 +87,6 @@ export class EditMeasureDialogComponent implements OnInit {
       operandName,
       index,
     );
-    this.previewMeasure.rerenderVisualizationComponent();
   }
 
   onKpiOperatorChange(operatorName: string, index: number) {
@@ -98,7 +96,6 @@ export class EditMeasureDialogComponent implements OnInit {
       operatorName,
       index,
     );
-    this.previewMeasure.rerenderVisualizationComponent();
   }
 
   onAddOperationClicked() {
@@ -125,7 +122,6 @@ export class EditMeasureDialogComponent implements OnInit {
       kpiVisualization.operationsElements.pop();
       kpiVisualization.operationsElements.pop();
     }
-    this.previewMeasure.rerenderVisualizationComponent();
   }
 
   onQueryNameChanged(value: string, i: number) {
@@ -141,7 +137,6 @@ export class EditMeasureDialogComponent implements OnInit {
       });
     }
     this.data.measure.queries[i].name = value;
-    this.previewMeasure.rerenderVisualizationComponent();
   }
 
   prettifyCustomMessageName(messageName: string) {

--- a/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.html
+++ b/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.html
@@ -2,93 +2,87 @@
   {{ 'success-modeling.pick-measure-dialog.title' | translate }}
 </h1>
 <div mat-dialog-content>
-  <mat-card
-    *ngIf="!data.measures || data.measures.length == 0"
-    class="no-measure-card"
+  <ng-container
+    *ngIf="measures$ | async as measures; else noMeasures"
   >
-    <mat-icon color="primary">info_outline</mat-icon>
-    <span>{{
-      'success-modeling.pick-measure-dialog.no-measures' | translate
-    }}</span>
-  </mat-card>
-  <div class="example-action-buttons">
-    <button mat-button (click)="accordion.openAll()">
-      Expand All
-    </button>
-    <button mat-button (click)="accordion.closeAll()">
-      Collapse All
-    </button>
-  </div>
-  <mat-accordion class="example-headers-align" multi>
-    <mat-expansion-panel
-      *ngFor="let measure of data.measures; let i = index"
-    >
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          {{ measure.name }}
-        </mat-panel-title>
-      </mat-expansion-panel-header>
+    <div class="example-action-buttons">
+      <button mat-button (click)="accordion.openAll()">
+        Expand All
+      </button>
+      <button mat-button (click)="accordion.closeAll()">
+        Collapse All
+      </button>
+    </div>
+    <mat-accordion class="example-headers-align" multi>
+      <mat-expansion-panel
+        *ngFor="let measure of measures; let i = index"
+      >
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            {{ measure.name }}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
 
-      <ng-template matExpansionPanelContent>
-        <div [ngSwitch]="measure.visualization.type">
-          <app-kpi-visualization
-            [measure]="measure"
-            [service]="service"
-            *ngSwitchCase="'KPI'"
-          ></app-kpi-visualization>
-          <app-value-visualization
-            [measureName]="measure.name"
-            [service]="service"
-            *ngSwitchCase="'Value'"
-          ></app-value-visualization>
-          <app-chart-visualization
-            *ngSwitchCase="'Chart'"
-            [measureName]="measure.name"
-            [service]="service"
-          ></app-chart-visualization>
-          <div *ngSwitchDefault>
-            Unknown chartType: {{ measureAsync.visualization.type }}
+        <ng-template matExpansionPanelContent>
+          <div [ngSwitch]="measure.visualization.type">
+            <app-kpi-visualization
+              [measure]="measure"
+              [service]="service"
+              *ngSwitchCase="'KPI'"
+            ></app-kpi-visualization>
+            <app-value-visualization
+              [measureName]="measure.name"
+              [service]="service"
+              *ngSwitchCase="'Value'"
+            ></app-value-visualization>
+            <app-chart-visualization
+              *ngSwitchCase="'Chart'"
+              [measureName]="measure.name"
+              [service]="service"
+            ></app-chart-visualization>
+            <div *ngSwitchDefault>
+              Unknown chartType: {{ measureAsync.visualization.type }}
+            </div>
           </div>
-        </div>
 
-        <div id="edit-controls">
-          <button
-            mat-icon-button
-            color="primary"
-            [matTooltip]="
-              'success-factor.add-measure-button' | translate
-            "
-            (click)="onMeasureClicked(measure)"
-          >
-            <mat-icon> playlist_add </mat-icon>
-          </button>
-          <button
-            *ngIf="canEdit$ | async"
-            mat-icon-button
-            color="primary"
-            [matTooltip]="
-              'success-modeling.edit-mode-toggle' | translate
-            "
-            (click)="onEditClicked(measure)"
-          >
-            <mat-icon> edit </mat-icon>
-          </button>
-          <button
-            *ngIf="canEdit$ | async"
-            mat-icon-button
-            color="warn"
-            [matTooltip]="
-              'success-factor.remove-measure-tooltip' | translate
-            "
-            (click)="deleteMeasure(i)"
-          >
-            <mat-icon> delete_forever </mat-icon>
-          </button>
-        </div>
-      </ng-template>
-    </mat-expansion-panel>
-  </mat-accordion>
-
+          <div id="edit-controls">
+            <button
+              mat-icon-button
+              color="primary"
+              [matTooltip]="
+                'success-factor.add-measure-button' | translate
+              "
+              (click)="onMeasureClicked(measure)"
+            >
+              <mat-icon> playlist_add </mat-icon>
+            </button>
+            <button
+              *ngIf="canEdit$ | async"
+              mat-icon-button
+              color="primary"
+              [matTooltip]="
+                'success-modeling.edit-mode-toggle' | translate
+              "
+              (click)="onEditClicked(measure)"
+            >
+              <mat-icon> edit </mat-icon>
+            </button>
+            <button
+              *ngIf="canEdit$ | async"
+              mat-icon-button
+              color="warn"
+              [matTooltip]="
+                'success-factor.remove-measure-tooltip' | translate
+              "
+              (click)="deleteMeasure(i)"
+            >
+              <mat-icon> delete_forever </mat-icon>
+            </button>
+          </div>
+        </ng-template>
+      </mat-expansion-panel>
+    </mat-accordion>
+  </ng-container>
   <button
     mat-raised-button
     color="primary"
@@ -101,3 +95,12 @@
     }}
   </button>
 </div>
+
+<ng-template #noMeasures>
+  <mat-card class="no-measure-card">
+    <mat-icon color="primary">info_outline</mat-icon>
+    <span>{{
+      'success-modeling.pick-measure-dialog.no-measures' | translate
+    }}</span>
+  </mat-card>
+</ng-template>

--- a/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.html
+++ b/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.html
@@ -21,6 +21,18 @@
           <mat-panel-title>
             {{ measure.name }}
           </mat-panel-title>
+          <mat-panel-description>
+            <button
+              mat-icon-button
+              color="primary"
+              [matTooltip]="
+                'success-factor.add-measure-button' | translate
+              "
+              (click)="onMeasureClicked(measure)"
+            >
+              <mat-icon> playlist_add </mat-icon>
+            </button>
+          </mat-panel-description>
         </mat-expansion-panel-header>
 
         <ng-template matExpansionPanelContent>
@@ -46,7 +58,7 @@
           </div>
 
           <div id="edit-controls">
-            <button
+            <!-- <button
               mat-icon-button
               color="primary"
               [matTooltip]="
@@ -55,7 +67,7 @@
               (click)="onMeasureClicked(measure)"
             >
               <mat-icon> playlist_add </mat-icon>
-            </button>
+            </button> -->
             <button
               *ngIf="canEdit$ | async"
               mat-icon-button

--- a/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.scss
+++ b/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.scss
@@ -1,43 +1,45 @@
-mat-card{
+mat-card {
   margin-bottom: 5px;
   cursor: pointer;
 }
 
-.no-measure-card{
+.no-measure-card {
   display: flex;
   flex-direction: row;
   align-items: center;
-  mat-icon{
+  mat-icon {
     margin-right: 10px;
   }
-  span{
+  span {
     flex-grow: 1;
   }
 }
 
-#create-measure-button{
+#create-measure-button {
   margin-top: 15px;
   width: 100%;
 }
 
-#edit-controls{
+#edit-controls {
   display: flex;
-  justify-content: space-around;
-  :last-child{
-    margin-left: auto;
-    margin-right: 0;
-  }
+  justify-content: flex-end;
 }
-.example-action-buttons{
-  margin-bottom:7px
+.example-action-buttons {
+  margin-bottom: 7px;
 }
-.example-headers-align .mat-expansion-panel-header-title,
-.example-headers-align .mat-expansion-panel-header-description {
-  flex-basis: 0;
-}
+// .example-headers-align .mat-expansion-panel-header-title,
+// .example-headers-align .mat-expansion-panel-header-description {
+//   flex-basis: 0;
+// }
 
 .example-headers-align .mat-expansion-panel-header-description {
-  justify-content: space-between;
+  align-items: center;
+}
+mat-panel-description {
+  justify-content: flex-end;
+  margin-right: 5px;
+}
+mat-panel-title {
   align-items: center;
 }
 

--- a/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.ts
+++ b/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.ts
@@ -55,7 +55,6 @@ export class PickMeasureDialogComponent implements OnInit {
   canEdit$ = this.ngrxStore.select(USER_HAS_EDIT_RIGHTS);
   service$ = this.ngrxStore.select(SELECTED_SERVICE);
   measures$ = this.ngrxStore.select(MEASURES).pipe(
-    tap((m) => console.log(m)),
     map((measures) =>
       !isEmpty(measures) ? Object.values(measures) : [],
     ),

--- a/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.ts
+++ b/src/app/success-factor/pick-measure-dialog/pick-measure-dialog.component.ts
@@ -25,12 +25,16 @@ import { ValueVisualization } from 'src/app/models/visualization.model';
 import { ServiceInformation } from 'src/app/models/service.model';
 import { Query } from 'src/app/models/query.model';
 import { MatAccordion } from '@angular/material/expansion';
+import { isEmpty } from 'lodash-es';
 import {
+  MEASURE,
+  MEASURES,
   SELECTED_SERVICE,
   USER_HAS_EDIT_RIGHTS,
 } from 'src/app/services/store.selectors';
 import { ConfirmationDialogComponent } from 'src/app/confirmation-dialog/confirmation-dialog.component';
 import { TranslateService } from '@ngx-translate/core';
+import { map, tap } from 'rxjs/operators';
 
 export interface DialogData {
   measures: Measure[];
@@ -50,6 +54,13 @@ export class PickMeasureDialogComponent implements OnInit {
   measuresChanged = new EventEmitter<Measure[]>();
   canEdit$ = this.ngrxStore.select(USER_HAS_EDIT_RIGHTS);
   service$ = this.ngrxStore.select(SELECTED_SERVICE);
+  measures$ = this.ngrxStore.select(MEASURES).pipe(
+    tap((m) => console.log(m)),
+    map((measures) =>
+      !isEmpty(measures) ? Object.values(measures) : [],
+    ),
+    map((measures) => (measures?.length > 0 ? measures : undefined)),
+  );
   service: ServiceInformation;
 
   constructor(
@@ -75,7 +86,7 @@ export class PickMeasureDialogComponent implements OnInit {
     this.dialogRef.close();
   }
 
-  openNewMeasureDialog() {
+  async openNewMeasureDialog() {
     const dialogRef = this.dialog.open(EditMeasureDialogComponent, {
       minWidth: 300,
       width: '80%',
@@ -90,18 +101,17 @@ export class PickMeasureDialogComponent implements OnInit {
         create: true,
       },
     });
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.data.measures.unshift(result);
-        this.ngrxStore.dispatch(
-          addMeasureToCatalog({ measure: result }),
-        );
-        // this.measuresChanged.emit(this.data.measures);
-      }
-    });
+    const result = await dialogRef.afterClosed().toPromise();
+    if (result) {
+      this.data.measures.unshift(result);
+      this.ngrxStore.dispatch(
+        addMeasureToCatalog({ measure: result }),
+      );
+      // this.measuresChanged.emit(this.data.measures);
+    }
   }
 
-  onEditClicked(measure: Measure) {
+  async onEditClicked(measure: Measure) {
     const dialogRef = this.dialog.open(EditMeasureDialogComponent, {
       minWidth: 300,
       width: '80%',
@@ -111,16 +121,15 @@ export class PickMeasureDialogComponent implements OnInit {
         create: false,
       },
     });
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.ngrxStore.dispatch(
-          editMeasureInCatalog({
-            measure: result,
-            oldMeasureName: measure.name,
-          }),
-        );
-      }
-    });
+    const result = await dialogRef.afterClosed().toPromise();
+    if (result) {
+      this.ngrxStore.dispatch(
+        editMeasureInCatalog({
+          measure: result,
+          oldMeasureName: measure.name,
+        }),
+      );
+    }
   }
 
   async deleteMeasure(measureIndex: number) {

--- a/src/app/success-factor/success-factor.component.ts
+++ b/src/app/success-factor/success-factor.component.ts
@@ -82,14 +82,13 @@ export class SuccessFactorComponent implements OnInit, OnDestroy {
       minWidth: 300,
       data: message,
     });
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.removeMeasure(measureIndex);
-      }
-    });
+    const result = await dialogRef.afterClosed();
+    if (result) {
+      this.removeMeasure(measureIndex);
+    }
   }
 
-  openPickMeasureDialog() {
+  async openPickMeasureDialog() {
     const dialogRef = this.dialog.open(PickMeasureDialogComponent, {
       minWidth: 300,
       width: '80%',
@@ -100,19 +99,19 @@ export class SuccessFactorComponent implements OnInit, OnDestroy {
         dimensionName: this.dimensionName,
       },
     });
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result) {
-        this.factor.measures.push((result as Measure).name);
-        this.ngrxStore.dispatch(
-          editFactorInDimension({
-            factor: this.factor,
-            oldFactorName: this.factor.name,
-            dimensionName: this.dimensionName,
-          }),
-        );
-      }
-    });
-    dialogRef.componentInstance.measuresChanged.subscribe(
+    const result = await dialogRef.afterClosed().toPromise();
+    if (result) {
+      this.factor.measures.push((result as Measure).name);
+      this.ngrxStore.dispatch(
+        editFactorInDimension({
+          factor: this.factor,
+          oldFactorName: this.factor.name,
+          dimensionName: this.dimensionName,
+        }),
+      );
+    }
+
+    const sub = dialogRef.componentInstance.measuresChanged.subscribe(
       (measures) => {
         const existingMeasures = [];
         for (const measure of measures) {
@@ -129,26 +128,26 @@ export class SuccessFactorComponent implements OnInit, OnDestroy {
         this.sendMeasuresToDimension.emit(this.measures);
       },
     );
+    this.subscriptions$.push(sub);
   }
 
-  onEditClicked() {
+  async onEditClicked() {
     const dialogRef = this.dialog.open(EditFactorDialogComponent, {
       width: '250px',
       data: { factor: { ...this.factor } },
     });
 
-    dialogRef.afterClosed().subscribe((result: SuccessFactor) => {
-      if (result) {
-        this.ngrxStore.dispatch(
-          editFactorInDimension({
-            factor: result,
-            oldFactorName: this.factor.name,
-            dimensionName: this.dimensionName,
-          }),
-        );
-        this.factor = result;
-      }
-    });
+    const result = await dialogRef.afterClosed().toPromise();
+    if (result) {
+      this.ngrxStore.dispatch(
+        editFactorInDimension({
+          factor: result,
+          oldFactorName: this.factor.name,
+          dimensionName: this.dimensionName,
+        }),
+      );
+      this.factor = result;
+    }
   }
 
   private removeMeasure(measureIndex: number) {

--- a/src/app/success-measure/success-measure.component.html
+++ b/src/app/success-measure/success-measure.component.html
@@ -1,23 +1,14 @@
 <div id="measure-header">
-  <!-- <button
-    mat-icon-button
-    *ngIf="canEdit$ | async"
-    color="warn"
-    (click)="onDeleteClicked($event)"
-    id="delete-button"
-  >
-    <mat-icon>remove_circle_outline</mat-icon>
-  </button> -->
   <button
+    *ngIf="!preview && (canEdit$ | async)"
     mat-icon-button
-    *ngIf="canEdit$ | async"
     color="primary"
     (click)="onEditClicked($event)"
     id="edit-button"
   >
     <mat-icon>edit</mat-icon>
   </button>
-  <h4 *ngIf="measure && displayTitle">
+  <h4 *ngIf="measure && !preview">
     {{ measure.name }}
   </h4>
 </div>

--- a/src/app/success-measure/success-measure.component.ts
+++ b/src/app/success-measure/success-measure.component.ts
@@ -49,7 +49,7 @@ export class SuccessMeasureComponent
   @Input() canDelete = false;
   @Input() dimensionName = '';
   @Input() factorName = '';
-  @Input() displayTitle = true;
+  @Input() preview = false;
 
   measure: Measure;
   measure$: Observable<Measure>;

--- a/src/app/success-modeling/requirements-list/requirements-list.component.ts
+++ b/src/app/success-modeling/requirements-list/requirements-list.component.ts
@@ -49,6 +49,7 @@ export class RequirementsListComponent
   frontendUrl = environment.reqBazFrontendUrl;
   openedRequirement = null;
   private user: User;
+  private subscriptions$ = [];
 
   constructor(
     private dialog: MatDialog,
@@ -69,7 +70,8 @@ export class RequirementsListComponent
   }
 
   ngOnInit() {
-    this.user$.subscribe((user) => (this.user = user));
+    const sub = this.user$.subscribe((user) => (this.user = user));
+    this.subscriptions$.push(sub);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -78,14 +80,16 @@ export class RequirementsListComponent
     }
   }
 
-  ngOnDestroy(): void {}
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((sub) => sub.unsubscribe());
+  }
 
   openPickProjectDialog() {
     const dialogRef = this.dialog.open(PickReqbazProjectComponent, {
       minWidth: 300,
       width: '80%',
     });
-    dialogRef.afterClosed().subscribe((result) => {
+    const sub = dialogRef.afterClosed().subscribe((result) => {
       if (result) {
         this.successModel = SuccessModel.fromPlainObject(
           cloneDeep(this.successModel),
@@ -106,10 +110,9 @@ export class RequirementsListComponent
             xml: this.successModel.toXml().outerHTML,
           }),
         );
-
-        this.refreshRequirements();
       }
     });
+    this.subscriptions$.push(sub);
   }
 
   async openDisconnectProjectDialog() {

--- a/src/app/success-modeling/requirements-list/requirements-list.component.ts
+++ b/src/app/success-modeling/requirements-list/requirements-list.component.ts
@@ -19,6 +19,7 @@ import { _USER } from 'src/app/services/store.selectors';
 import {
   addReqBazarProject,
   removeReqBazarProject,
+  setNumberOfRequirements,
   storeSuccessModel,
 } from 'src/app/services/store.actions';
 import { User } from 'src/app/models/user.model';
@@ -64,11 +65,6 @@ export class RequirementsListComponent
   }
 
   ngOnInit() {
-    this.refreshRequirements();
-    this.refreshRequirementsHandle = setInterval(
-      () => this.refreshRequirements(),
-      environment.servicePollingInterval * 1000,
-    );
     this.user$.subscribe((user) => (this.user = user));
   }
 
@@ -140,9 +136,14 @@ export class RequirementsListComponent
             xml: this.successModel.toXml().outerHTML,
           }),
         );
+        this.setNumberOfRequirements(0);
         this.numberOfRequirements.emit(0);
       }
     });
+  }
+
+  setNumberOfRequirements(n: number) {
+    this.ngrxStore.dispatch(setNumberOfRequirements({ n }));
   }
 
   refreshRequirements() {
@@ -156,6 +157,7 @@ export class RequirementsListComponent
       )
       .then((requirements) => {
         this.requirements = requirements;
+        this.setNumberOfRequirements((requirements as [])?.length);
         this.numberOfRequirements.emit((requirements as []).length);
       });
   }

--- a/src/app/success-modeling/success-modeling.component.html
+++ b/src/app/success-modeling/success-modeling.component.html
@@ -15,7 +15,7 @@
       <!-- workspace management -->
       <app-workspace-management></app-workspace-management>
 
-      <!-- Success model -->
+      <!-- Success modeling -->
       <ng-container
         *ngIf="
           selectedService$ | async as selectedService;
@@ -36,22 +36,28 @@
                     }
             }}
           </h3>
-          <ng-container
-            *ngIf="
-              !(showSuccessModelEmpty$ | async);
-              else successModelEmpty
-            "
-          >
-            <ng-container
-              *ngIf="
-                successModel$ | async as successModel;
-                else noSuccessModel
-              "
-            >
-              <ng-container
-                *ngIf="measureCatalog$ | async as measureCatalog"
+          <ng-container *ngIf="!(editMode$ | async)">
+            <ng-container *ngIf="successModelEmpty$ | async">
+              <mat-card
+                id="model-empty-info"
+                *ngIf="
+                  memberOfGroup$ | async;
+                  else notMemberOfSelectedGroup
+                "
               >
-                <!-- <app-questionnaires
+                <mat-icon color="accent"> info_outline </mat-icon>
+                {{
+                  'success-modeling.message-no-success-model-found'
+                    | translate
+                }}
+              </mat-card>
+            </ng-container>
+          </ng-container>
+          <ng-container *ngIf="successModel$ | async as successModel">
+            <ng-container
+              *ngIf="measureCatalog$ | async as measureCatalog"
+            >
+              <!-- <app-questionnaires
                   [availableQuestionnaires]="availableQuestionnaires"
                   [model]="successModel"
                   [measures]="measureCatalog.measures"
@@ -59,49 +65,46 @@
                   [editMode]="editMode$ | async"
                   [groupID]="(selectedGroup$ | async).id"
                 ></app-questionnaires> -->
-                <div id="dimensions">
-                  <app-success-dimension
-                    [@slideInOut]
-                    *ngFor="let dimension of dimensions"
-                    [factors]="successModel.dimensions[dimension]"
-                    [measures]="measureCatalog.measures"
-                    name="{{
-                      'success-modeling.dimensions.name.' +
-                        translationMap[dimension] | translate
-                    }}"
-                    description="{{
-                      'success-modeling.dimensions.description.' +
-                        translationMap[dimension] | translate
-                    }}"
-                    icon="{{ iconMap[dimension] }}"
-                  ></app-success-dimension>
-                </div>
-                <button
-                  id="save-model-button"
-                  mat-raised-button
-                  *ngIf="saveEnabled$ | async"
-                  color="primary"
-                  [disabled]="saveInProgress"
-                  (click)="onSaveClicked()"
+              <div id="dimensions">
+                <app-success-dimension
+                  *ngFor="let dimension of dimensions"
+                  [factors]="successModel.dimensions[dimension]"
+                  [measures]="measureCatalog.measures"
+                  name="{{
+                    'success-modeling.dimensions.name.' +
+                      translationMap[dimension] | translate
+                  }}"
+                  description="{{
+                    'success-modeling.dimensions.description.' +
+                      translationMap[dimension] | translate
+                  }}"
+                  icon="{{ iconMap[dimension] }}"
+                ></app-success-dimension>
+              </div>
+              <button
+                id="save-model-button"
+                mat-raised-button
+                *ngIf="saveEnabled$ | async"
+                color="primary"
+                [disabled]="saveInProgress"
+                (click)="onSaveClicked()"
+              >
+                <mat-spinner
+                  *ngIf="saveInProgress"
+                  color="warn"
+                  [diameter]="25"
                 >
-                  <mat-spinner
-                    *ngIf="saveInProgress"
-                    color="warn"
-                    [diameter]="25"
-                  >
-                  </mat-spinner>
-                  {{
-                    'success-modeling.save-model-button' | translate
-                  }}
-                </button>
-              </ng-container>
-            </ng-container></ng-container
-          >
-        </ng-container>
+                </mat-spinner>
+                {{ 'success-modeling.save-model-button' | translate }}
+              </button>
+            </ng-container>
+          </ng-container></ng-container
+        >
       </ng-container>
     </ng-container>
   </ng-container>
 </ng-container>
+
 <ng-template #noGroupSelect>
   <mat-card>
     {{ 'success-modeling.no-group-selected' | translate }}
@@ -112,17 +115,6 @@
   <mat-card>{{
     'success-modeling.message-no-application-selected' | translate
   }}</mat-card>
-</ng-template>
-
-<ng-template #successModelEmpty>
-  <!-- success model non existant -->
-  <mat-card
-    *ngIf="memberOfGroup$ | async; else notMemberOfSelectedGroup"
-  >
-    {{
-      'success-modeling.message-no-success-model-found' | translate
-    }}
-  </mat-card>
 </ng-template>
 
 <ng-template #notInitialized>

--- a/src/app/success-modeling/success-modeling.component.scss
+++ b/src/app/success-modeling/success-modeling.component.scss
@@ -39,6 +39,10 @@ app-success-dimension {
     align-items: center;
   }
 }
+#model-empty-info{
+  display: flex;
+  align-items: center;
+}
 
 #info-content {
   display: flex;

--- a/src/app/success-modeling/success-modeling.component.ts
+++ b/src/app/success-modeling/success-modeling.component.ts
@@ -26,6 +26,7 @@ import {
 import {
   catchError,
   filter,
+  isEmpty,
   map,
   timeout,
   withLatestFrom,
@@ -71,12 +72,12 @@ export class SuccessModelingComponent implements OnInit, OnDestroy {
 
   editMode$ = this.ngrxStore.select(_EDIT_MODE);
   successModel$ = this.ngrxStore.select(SUCCESS_MODEL);
-  showSuccessModelEmpty$ = this.ngrxStore
-    .select(SUCCESS_MODEL_IS_EMPTY)
-    .pipe(
-      withLatestFrom(this.editMode$),
-      map(([empty, editMode]) => empty && !editMode),
-    );
+  successModelEmpty$ = this.ngrxStore.select(SUCCESS_MODEL_IS_EMPTY);
+  showSuccessModellingView$ = combineLatest([
+    this.successModelEmpty$,
+    this.editMode$,
+  ]).pipe(map(([empty, editMode]) => editMode && !empty));
+
   measureCatalog$ = this.ngrxStore.select(MEASURE_CATALOG);
   selectedService$ = this.ngrxStore.select(SELECTED_SERVICE);
   selectedGroup$ = this.ngrxStore.select(SELECTED_GROUP);
@@ -128,7 +129,11 @@ export class SuccessModelingComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private ngrxStore: Store,
     private actionState: StateEffects,
-  ) {}
+  ) {
+    this.showSuccessModellingView$.subscribe((data) =>
+      console.log(data),
+    );
+  }
 
   ngOnInit() {
     let sub = this.selectedService$

--- a/src/app/success-modeling/success-modeling.component.ts
+++ b/src/app/success-modeling/success-modeling.component.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import {
   disableEdit,
   failureResponse,
-  PostActions,
+  HttpActions,
   saveModelAndCatalog,
   setService,
   toggleEdit,
@@ -198,7 +198,7 @@ export class SuccessModelingComponent implements OnInit, OnDestroy {
         )
         .subscribe((result) => {
           this.saveInProgress = false;
-          if (result.type === PostActions.SAVE_CATALOG_SUCCESS) {
+          if (result.type === HttpActions.SAVE_CATALOG_SUCCESS) {
             const message = this.translate.instant(
               'success-modeling.snackbar-save-success',
             );

--- a/src/app/success-modeling/success-modeling.component.ts
+++ b/src/app/success-modeling/success-modeling.component.ts
@@ -7,11 +7,9 @@ import {
   HttpActions,
   saveModelAndCatalog,
   setService,
-  toggleEdit,
 } from '../services/store.actions';
 import {
   MODEL_AND_CATALOG_LOADED,
-  DIMENSIONS_IN_MODEL,
   _EDIT_MODE,
   IS_MEMBER_OF_SELECTED_GROUP,
   MEASURE_CATALOG,
@@ -26,7 +24,6 @@ import {
 import {
   catchError,
   filter,
-  isEmpty,
   map,
   timeout,
   withLatestFrom,
@@ -129,11 +126,7 @@ export class SuccessModelingComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private ngrxStore: Store,
     private actionState: StateEffects,
-  ) {
-    this.showSuccessModellingView$.subscribe((data) =>
-      console.log(data),
-    );
-  }
+  ) {}
 
   ngOnInit() {
     let sub = this.selectedService$

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.html
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.html
@@ -6,10 +6,10 @@
           'success-modeling.visualization.fetch-info'
             | translate: { date: data.fetchDate | date: 'short' }
         }}
-        <p *ngIf="data.error">
+        <p *ngIf="error$ | async as error">
           {{
             'success-modeling.visualization.fetch-error'
-              | translate: { error: data.error.error }
+              | translate: { error: error.error }
           }}
         </p>
       </div>
@@ -41,7 +41,7 @@
 
 <ng-template #noData>
   <span
-    *ngIf="error && !chartData; else noDataAndNoError"
+    *ngIf="(error$ | async) && !chartData; else noDataAndNoError"
     (click)="openErrorDialog()"
     class="visualization-error"
   >

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.html
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.html
@@ -23,7 +23,7 @@
       [options]="this.chartData.options"
       [columns]="columnNames"
       [dynamicResize]="true"
-      [style]="'display: ' + chartInitialized ? 'block' : 'none'"
+      [style]="fadeInAnimation()"
       class="content"
       style="width: 100%"
       (ready)="this.chartInitialized = true"

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.ts
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.ts
@@ -6,12 +6,22 @@ import {
   MEASURE,
   VISUALIZATION_DATA_FOR_QUERY,
 } from 'src/app/services/store.selectors';
-import { distinctUntilChanged, filter, tap } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import {
+  distinctUntilChanged,
+  distinctUntilKeyChanged,
+  filter,
+  map,
+  switchMap,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
+import { Observable, Subscription } from 'rxjs';
 import { Measure } from 'src/app/models/measure.model';
 import {
   ChartVisualization,
   VData,
+  Visualization,
+  VisualizationData,
 } from 'src/app/models/visualization.model';
 import { GoogleChart } from 'src/app/models/chart.model';
 import { ServiceInformation } from 'src/app/models/service.model';
@@ -26,14 +36,15 @@ export class ChartVisualizerComponent
   implements OnInit
 {
   @Input() measureName: string;
-  @Input() service: ServiceInformation;
 
-  data$: Observable<VData>;
-  measure$: Observable<Measure>;
+  query$: Observable<string>;
+
   query: string; // local copy of the sql query
   chartData: GoogleChart;
   chartInitialized = false;
+  visualization: ChartVisualization;
 
+  subscriptions$: Subscription[] = [];
   constructor(
     protected dialog: MatDialog,
     protected ngrxStore: Store,
@@ -42,77 +53,77 @@ export class ChartVisualizerComponent
   }
 
   ngOnInit() {
-    this.service$
-      .pipe(filter((service) => !!service))
-      .subscribe((service) => {
-        this.service = service;
-        this.measure$ = this.ngrxStore
-          .select(MEASURE, this.measureName) // selects the measure from the measure catalog
-          .pipe(
-            filter((data) => !!data),
-            distinctUntilChanged(),
+    this.measure$ = this.ngrxStore
+      .select(MEASURE, this.measureName) // selects the measure from the measure catalog
+      .pipe(
+        filter((measure) => !!measure),
+        distinctUntilKeyChanged('queries'),
+      );
+    this.query$ = this.measure$.pipe(
+      withLatestFrom(this.service$),
+      map(([measure, service]) => {
+        let query = measure.queries[0].sql;
+        const queryParams = this.getParamsForQuery(query);
+        query = this.applyVariableReplacements(query, service);
+        query =
+          BaseVisualizationComponent.applyCompatibilityFixForVisualizationService(
+            query,
           );
-        this.measure$
-          .pipe(filter((data) => !!data))
-          .subscribe((measure: Measure) => {
-            this.prepareChart(measure);
-          });
+        super.fetchVisualizationData(query, queryParams);
+        return query;
+      }),
+      distinctUntilChanged(),
+    );
+    this.data$ = this.query$.pipe(
+      switchMap((query) =>
+        this.ngrxStore.select(VISUALIZATION_DATA_FOR_QUERY, query),
+      ),
+    );
+    const error$ = this.data$.pipe(map((data) => data?.error));
+    let sub = error$.subscribe((err) => {
+      this.error = err;
+    });
+    this.subscriptions$.push(sub);
+    sub = this.data$
+      .pipe(
+        map((vdata) => vdata.data),
+        filter((data) => data instanceof Array && data.length >= 2),
+        withLatestFrom(this.measure$),
+      )
+      .subscribe(([dataTable, measure]) => {
+        this.prepareChart(dataTable, measure.visualization);
       });
+    this.subscriptions$.push(sub);
   }
 
   /**
    * Prepares chart for given measure
    * @param measure success measure
    */
-  private prepareChart(measure: Measure) {
-    if (!measure) return;
-    const visualization = measure.visualization as ChartVisualization;
-    let query = measure.queries[0].sql;
-    const queryParams = this.getParamsForQuery(query);
-
-    query = this.applyVariableReplacements(query, this.service);
-    query =
-      BaseVisualizationComponent.applyCompatibilityFixForVisualizationService(
-        query,
-      );
-
-    if (this.query !== query) {
-      this.query = query;
-      super.fetchVisualizationData(query, queryParams);
-      this.data$ = this.ngrxStore.select(
-        VISUALIZATION_DATA_FOR_QUERY,
-        query,
-      );
-      this.data$
-        .pipe(tap((data) => (this.error = data?.error)))
-        .subscribe((vdata) => {
-          if (!vdata || vdata?.error) {
-            return super.fetchVisualizationData(query, queryParams);
-          }
-          const dataTable = vdata.data;
-          if (dataTable instanceof Array && dataTable.length >= 2) {
-            this.error = null;
-            const labelTypes = dataTable[1];
-            const rows = dataTable.slice(2) as any[][];
-            this.chartData = new GoogleChart(
-              '',
-              visualization.chartType,
-              rows,
-              dataTable[0],
-              {
-                colors: [
-                  '#00a895',
-                  '#9500a8',
-                  '#a89500',
-                  '#ff5252',
-                  '#ffd600',
-                ],
-                animation: { startup: true },
-              },
-            );
-            if (this.chartData) this.visualizationInitialized = true;
-          }
-        });
-    }
+  private prepareChart(
+    dataTable: any[][],
+    visualization: Visualization,
+  ) {
+    visualization = visualization as ChartVisualization;
+    this.error = null;
+    const labelTypes = dataTable[1];
+    const rows = dataTable.slice(2) as any[][];
+    this.chartData = new GoogleChart(
+      '',
+      (visualization as ChartVisualization).chartType,
+      rows,
+      dataTable[0],
+      {
+        colors: [
+          '#00a895',
+          '#9500a8',
+          '#a89500',
+          '#ff5252',
+          '#ffd600',
+        ],
+        animation: { startup: true },
+      },
+    );
+    // if (this.chartData) this.visualizationInitialized = true;
   }
 }

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.ts
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { BaseVisualizationComponent } from '../visualization.component';
 import { MatDialog } from '@angular/material/dialog';
 import { Store } from '@ngrx/store';
@@ -43,7 +43,7 @@ import {
 })
 export class ChartVisualizerComponent
   extends BaseVisualizationComponent
-  implements OnInit
+  implements OnInit, OnDestroy
 {
   @Input() measureName: string;
 
@@ -60,6 +60,12 @@ export class ChartVisualizerComponent
     protected ngrxStore: Store,
   ) {
     super(ngrxStore, dialog);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((subscription) =>
+      subscription.unsubscribe(),
+    );
   }
 
   ngOnInit() {

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.ts
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.ts
@@ -28,6 +28,13 @@ import {
 } from 'src/app/models/visualization.model';
 import { GoogleChart } from 'src/app/models/chart.model';
 import { ServiceInformation } from 'src/app/models/service.model';
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 
 @Component({
   selector: 'app-chart-visualization',
@@ -145,5 +152,13 @@ export class ChartVisualizerComponent
       },
     );
     // if (this.chartData) this.visualizationInitialized = true;
+  }
+
+  fadeInAnimation() {
+    if (this.chartInitialized) {
+      return 'opacity: 1;transition: opacity 1s ease-out;';
+    } else {
+      return 'opacity: 0;';
+    }
   }
 }

--- a/src/app/visualizations/value-visualization/value-visualization.component.html
+++ b/src/app/visualizations/value-visualization/value-visualization.component.html
@@ -7,9 +7,7 @@
     <ng-container *ngIf="value$ | async as value; else noData">
       <span class="value-visualization">
         {{ value }}
-        <ng-container
-          *ngIf="measure?.visualization?.unit !== 'undefined'"
-        >
+        <ng-container *ngIf="measure?.visualization?.unit">
           {{ measure.visualization.unit }}
         </ng-container>
       </span>

--- a/src/app/visualizations/value-visualization/value-visualization.component.ts
+++ b/src/app/visualizations/value-visualization/value-visualization.component.ts
@@ -20,15 +20,16 @@ import {
 import { Observable, Subscription } from 'rxjs';
 import { VData } from 'src/app/models/visualization.model';
 import {
+  distinctUntilChanged,
   distinctUntilKeyChanged,
   filter,
   map,
+  mergeMap,
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
 import { ServiceInformation } from 'src/app/models/service.model';
 import { Measure } from 'src/app/models/measure.model';
-import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-value-visualization',
@@ -43,7 +44,7 @@ export class ValueVisualizationComponent
 
   data$: Observable<VData>;
   measure$: Observable<Measure>;
-  error$: Observable<HttpErrorResponse>;
+  query$: Observable<string>;
   value$: Observable<string>;
   service$: Observable<ServiceInformation> = this.ngrxStore
     .select(SELECTED_SERVICE)
@@ -60,48 +61,45 @@ export class ValueVisualizationComponent
     super(ngrxStore, dialog);
   }
 
-  ngOnDestroy() {
-    this.subscriptions$.forEach((sub) => sub.unsubscribe());
-  }
-
   ngOnInit() {
-    this.measure$ = this.ngrxStore.select(MEASURE, this.measureName);
+    // selects the measure from the measure catalog
+    this.measure$ = this.ngrxStore
+      .select(MEASURE, this.measureName)
+      .pipe(
+        filter((measure) => !!measure),
+        distinctUntilKeyChanged('queries'),
+      );
 
-    const sub = this.measure$
-      .pipe(withLatestFrom(this.service$))
-      .subscribe(([measure, service]) => {
-        this.measure = measure;
-        this.service = service;
-        let query = this.measure?.queries[0].sql;
-
-        const queryParams = this.getParamsForQuery(query);
-        query = this.applyVariableReplacements(query, this.service);
+    // gets the query string from the measure and applies variable replacements
+    this.query$ = this.measure$.pipe(
+      withLatestFrom(this.service$),
+      map(([measure, service]) => {
+        let query = measure.queries[0].sql;
+        query = this.applyVariableReplacements(query, service);
         query =
           BaseVisualizationComponent.applyCompatibilityFixForVisualizationService(
             query,
           );
-        super.fetchVisualizationData(query, queryParams);
-        this.data$ = this.ngrxStore.select(
-          VISUALIZATION_DATA_FOR_QUERY,
-          query,
-        );
-        this.error$ = this.data$.pipe(map((data) => data?.error));
-        this.value$ = this.data$.pipe(
-          map((visualizationData) => visualizationData?.data),
-          filter((data) => !!data),
-          map((data) =>
-            data.slice(-1)[0].length === 0 ? 0 : data.slice(-1)[0][0],
-          ),
-        );
-        // this.data$.pipe(filter((data) => !!data)).subscribe((v) => {
-        //   this.value =
-        //     v?.data?.slice(-1)[0]?.length === 0
-        //       ? 0
-        //       : v.data.slice(-1)[0][0];
-        //   this.visualizationInitialized = true;
-        // });
-      });
+        return query;
+      }),
+      distinctUntilChanged(),
+    );
+    // selects the query data for the query from the store
+    this.data$ = this.query$.pipe(
+      filter((query) => !!query),
+      mergeMap((query) =>
+        this.ngrxStore.select(VISUALIZATION_DATA_FOR_QUERY, query),
+      ),
+    );
 
-    this.subscriptions$.push(sub);
+    this.error$ = this.data$.pipe(map((data) => data?.error));
+
+    this.value$ = this.data$.pipe(
+      map((visualizationData) => visualizationData?.data),
+      filter((data) => !!data),
+      map((data) =>
+        data.slice(-1)[0].length === 0 ? 0 : data.slice(-1)[0][0],
+      ),
+    );
   }
 }

--- a/src/app/visualizations/value-visualization/value-visualization.component.ts
+++ b/src/app/visualizations/value-visualization/value-visualization.component.ts
@@ -62,6 +62,12 @@ export class ValueVisualizationComponent
     super(ngrxStore, dialog);
   }
 
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((subscription) =>
+      subscription.unsubscribe(),
+    );
+  }
+
   ngOnInit() {
     // selects the measure from the measure catalog
     this.measure$ = this.ngrxStore

--- a/src/app/visualizations/value-visualization/value-visualization.component.ts
+++ b/src/app/visualizations/value-visualization/value-visualization.component.ts
@@ -87,7 +87,7 @@ export class ValueVisualizationComponent
         );
         this.error$ = this.data$.pipe(map((data) => data?.error));
         this.value$ = this.data$.pipe(
-          map((visualizationData) => visualizationData.data),
+          map((visualizationData) => visualizationData?.data),
           filter((data) => !!data),
           map((data) =>
             data.slice(-1)[0].length === 0 ? 0 : data.slice(-1)[0][0],

--- a/src/app/visualizations/value-visualization/value-visualization.component.ts
+++ b/src/app/visualizations/value-visualization/value-visualization.component.ts
@@ -23,6 +23,7 @@ import {
   distinctUntilChanged,
   distinctUntilKeyChanged,
   filter,
+  first,
   map,
   mergeMap,
   tap,
@@ -101,5 +102,19 @@ export class ValueVisualizationComponent
         data.slice(-1)[0].length === 0 ? 0 : data.slice(-1)[0][0],
       ),
     );
+
+    const sub = this.measure$
+      .pipe(withLatestFrom(this.service$), first())
+      .subscribe(([measure, service]) => {
+        let query = measure.queries[0].sql;
+        const queryParams = this.getParamsForQuery(query);
+        query = this.applyVariableReplacements(query, service);
+        query =
+          BaseVisualizationComponent.applyCompatibilityFixForVisualizationService(
+            query,
+          );
+        super.fetchVisualizationData(query, queryParams);
+      });
+    this.subscriptions$.push(sub);
   }
 }

--- a/src/app/visualizations/visualization.component.ts
+++ b/src/app/visualizations/visualization.component.ts
@@ -44,6 +44,7 @@ export class BaseVisualizationComponent
   service$ = this.ngrxStore.select(SELECTED_SERVICE);
   measure$: Observable<Measure>;
   data$: Observable<VData>;
+  error$: Observable<HttpErrorResponse>;
   subscriptions$: Subscription[] = [];
 
   service: ServiceInformation;
@@ -93,6 +94,9 @@ export class BaseVisualizationComponent
       .subscribe((service) => {
         this.service = service;
       });
+
+    const sub = this.error$.subscribe((err) => (this.error = err));
+    this.subscriptions$.push(sub);
   }
 
   ngOnDestroy(): void {

--- a/src/app/visualizations/visualization.component.ts
+++ b/src/app/visualizations/visualization.component.ts
@@ -12,11 +12,13 @@ import { fetchVisualizationData } from '../services/store.actions';
 import { ServiceInformation } from '../models/service.model';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Measure } from '../models/measure.model';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import {
   MEASURE,
   SELECTED_SERVICE,
 } from '../services/store.selectors';
+import { VData } from '../models/visualization.model';
+import { filter } from 'rxjs/operators';
 
 export interface VisualizationComponent {
   service: ServiceInformation;
@@ -40,6 +42,10 @@ export class BaseVisualizationComponent
   ) {}
   measure: Measure;
   service$ = this.ngrxStore.select(SELECTED_SERVICE);
+  measure$: Observable<Measure>;
+  data$: Observable<VData>;
+  subscriptions$: Subscription[] = [];
+
   service: ServiceInformation;
   visualizationInitialized = false;
   public serviceNotFoundInMobSOS = false;
@@ -81,9 +87,19 @@ export class BaseVisualizationComponent
     return query?.replace('$SERVICES$', servicesString);
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.service$
+      .pipe(filter((service) => !!service))
+      .subscribe((service) => {
+        this.service = service;
+      });
+  }
 
-  ngOnDestroy(): void {}
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((subscription) =>
+      subscription.unsubscribe(),
+    );
+  }
 
   openErrorDialog(error?: HttpErrorResponse) {
     if (error) {

--- a/src/app/visualizations/visualization.component.ts
+++ b/src/app/visualizations/visualization.component.ts
@@ -99,6 +99,11 @@ export class BaseVisualizationComponent
     this.subscriptions$.push(sub);
   }
 
+  /** Note that lifecycle hooks are not called by components
+   * which inherit from this class
+   * Thus we need to unsubscribe from all subscriptions in the component itself
+   * as mentioned on @link https://medium.com/@saniyusuf/part-1-the-case-for-component-inheritance-in-angular-a34fe2a0f7ac
+   */
   ngOnDestroy(): void {
     this.subscriptions$.forEach((subscription) =>
       subscription.unsubscribe(),

--- a/src/app/workspace-management/workspace-management.component.html
+++ b/src/app/workspace-management/workspace-management.component.html
@@ -40,7 +40,7 @@
     <div id="workspace-controls" *ngIf="editMode$ | async">
       <button
         mat-icon-button
-        [matMenuTriggerFor]="reqMenu"
+        (click)="openBottomSheet()"
         aria-label="Requirements Bazaar"
         matTooltip="{{
           'success-modeling.reqbaz.tooltip' | translate
@@ -49,9 +49,7 @@
         <mat-icon
           color="primary"
           svgIcon="reqbaz-logo"
-          [matBadge]="
-            numberOfRequirements === 0 ? null : numberOfRequirements
-          "
+          [matBadge]="numberOfRequirements$ | async"
           matBadgeColor="accent"
         >
         </mat-icon>
@@ -137,16 +135,6 @@
   </mat-card>
 </ng-container>
 
-<!-- menu for Requirements Bazar -->
-<mat-menu #reqMenu="matMenu">
-  <mat-card-content class="card">
-    <app-requirements-list
-      [successModel]="successModel$ | async"
-      (numberOfRequirements)="numberOfRequirements = $event.valueOf()"
-    >
-    </app-requirements-list>
-  </mat-card-content>
-</mat-menu>
 <!-- menu for visitors -->
 <mat-menu #groupMenu>
   <ng-container

--- a/src/app/workspace-management/workspace-management.component.html
+++ b/src/app/workspace-management/workspace-management.component.html
@@ -163,7 +163,9 @@
                       | translate
                   }}"
                   matTooltipShowDelay="0"
-                  (click)="onChangeRole(visitor.username, 'editor')"
+                  (click)="
+                    onChangeRole(visitor.username, 'editor', $event)
+                  "
                 >
                   <mat-icon>create</mat-icon>
                 </button>
@@ -176,7 +178,11 @@
                   }}"
                   matTooltipShowDelay="0"
                   (click)="
-                    onChangeRole(visitor.username, 'spectator')
+                    onChangeRole(
+                      visitor.username,
+                      'spectator',
+                      $event
+                    )
                   "
                 >
                   <mat-icon>remove_red_eye</mat-icon>

--- a/src/app/workspace-management/workspace-management.component.html
+++ b/src/app/workspace-management/workspace-management.component.html
@@ -148,38 +148,42 @@
       <mat-list role="list">
         <mat-list-item
           *ngFor="let visitor of foreign_visitors"
-          id="visitor"
           role="listitem"
-          >{{ visitor.username }}
+        >
+          <div id="visitor">
+            <span>{{ visitor.username }}</span>
 
-          <ng-container *ngIf="userIsOwner$ | async">
-            <ng-container [ngSwitch]="visitor.role">
-              <button
-                *ngSwitchCase="'spectator'"
-                mat-icon-button
-                matTooltip="{{
-                  'success-modeling.visitors.edit-role-description'
-                    | translate
-                }}"
-                matTooltipShowDelay="0"
-                (click)="onChangeRole(visitor.username, 'editor')"
-              >
-                <mat-icon>create</mat-icon>
-              </button>
-              <button
-                *ngSwitchCase="'editor'"
-                mat-icon-button
-                matTooltip="{{
-                  'success-modeling.visitors.spectator-role-description'
-                    | translate
-                }}"
-                matTooltipShowDelay="0"
-                (click)="onChangeRole(visitor.username, 'spectator')"
-              >
-                <mat-icon>remove_red_eye</mat-icon>
-              </button>
-            </ng-container>
-          </ng-container></mat-list-item
+            <span *ngIf="userIsOwner$ | async">
+              <ng-container [ngSwitch]="visitor.role">
+                <button
+                  *ngSwitchCase="'spectator'"
+                  mat-icon-button
+                  matTooltip="{{
+                    'success-modeling.visitors.edit-role-description'
+                      | translate
+                  }}"
+                  matTooltipShowDelay="0"
+                  (click)="onChangeRole(visitor.username, 'editor')"
+                >
+                  <mat-icon>create</mat-icon>
+                </button>
+                <button
+                  *ngSwitchCase="'editor'"
+                  mat-icon-button
+                  matTooltip="{{
+                    'success-modeling.visitors.spectator-role-description'
+                      | translate
+                  }}"
+                  matTooltipShowDelay="0"
+                  (click)="
+                    onChangeRole(visitor.username, 'spectator')
+                  "
+                >
+                  <mat-icon>remove_red_eye</mat-icon>
+                </button>
+              </ng-container>
+            </span>
+          </div></mat-list-item
         >
       </mat-list>
     </mat-card-content>

--- a/src/app/workspace-management/workspace-management.component.scss
+++ b/src/app/workspace-management/workspace-management.component.scss
@@ -21,11 +21,11 @@ app-success-dimension {
     margin-bottom: auto;
   }
 }
-.card{
+.card {
   padding: 1rem;
 }
-.mat-card-content{
-  margin-bottom:0
+.mat-card-content {
+  margin-bottom: 0;
 }
 .popover-content {
   max-width: 300px;
@@ -48,13 +48,21 @@ app-success-dimension {
   }
 }
 
-#edit-controls{
-  display: flex; align-items: center
+#edit-controls {
+  display: flex;
+  align-items: center;
 }
 
-#visitor{
+#visitor {
   display: flex;
-  justify-content:space-between;
   align-items: center;
+  justify-content: space-between;
   width: 100%;
+  
+}
+
+.popover-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }

--- a/src/app/workspace-management/workspace-management.component.ts
+++ b/src/app/workspace-management/workspace-management.component.ts
@@ -239,13 +239,14 @@ export class WorkspaceManagementComponent
     this._bottomSheet.open(BottomSheetComponent);
   }
 
-  onChangeRole(visitorName: string, role?: string) {
+  onChangeRole(visitorName: string, role?: string, event?) {
     this.workspaceService.changeVisitorRole(
       visitorName,
       this.workspaceOwner,
       this.selectedServiceName,
       role,
     );
+    event.stopPropagation();
   }
 
   shareWorkspaceLink() {

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -4,5 +4,5 @@
   window['env']['las2peerWebConnectorUrl'] = '${BOOTSTRAP}';
   window['env']['yJsWebsocketUrl'] = '${Y_WEBSOCKET}';
   window['env']['openIdClientId'] = '${OIDC_CLIENT_ID}';
-  window['env']['production'] = !'${DEBUG}';
+  window['env']['production'] = '${PRODUCTION}';
 })(this);

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -29,7 +29,7 @@ export const environment = {
   // mobsosSurveysUrl: 'http://127.0.0.1:8080/mobsos-surveys/',
   servicePollingInterval: 120,
   // interval at which visualizations should be refetched in minutes
-  visualizationRefreshInterval: 5,
+  visualizationRefreshInterval: 30,
   // enable to use the blockchain based service discovery of las2peer
   useLas2peerServiceDiscovery: false,
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -29,7 +29,7 @@ export const environment = {
   // mobsosSurveysUrl: 'http://127.0.0.1:8080/mobsos-surveys/',
   servicePollingInterval: 120,
   // interval at which visualizations should be refetched in minutes
-  visualizationRefreshInterval: 10,
+  visualizationRefreshInterval: 5,
   // enable to use the blockchain based service discovery of las2peer
   useLas2peerServiceDiscovery: false,
 

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -6,6 +6,7 @@ export const translations = {
       'manage-requirements': 'Anforderungen verwalten',
       'success-modeling': 'Erfolgsmodellierung',
       'raw-edit': 'Direktbearbeitung',
+      'add-community': 'Community hinzufügen',
     },
     elements: {
       'cancel-label': 'Cancel',
@@ -25,6 +26,7 @@ export const translations = {
         'Einloggen um eine Community auszuwählen',
       'your-groups-hint': 'Deine Gruppen',
       'foreign-groups-hint': 'Andere Gruppen',
+       'pick-community-name':  'Wähle einen Gruppen Namen',
     },
     'language-selector': {
       'select-language': 'Sprache auswählen',

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -6,6 +6,7 @@ export const translations = {
       'manage-requirements': 'Manage Requirements',
       'success-modeling': 'Success Modeling',
       'raw-edit': 'Raw Edit',
+      'add-community': 'Add Community',
     },
     elements: {
       'cancel-label': 'Cancel',
@@ -24,6 +25,7 @@ export const translations = {
       'select-community-hint': 'Login to select your community',
       'your-groups-hint': 'Your Groups',
       'foreign-groups-hint': 'Foreign Groups',
+      'pick-community-name':  'Pick a unique community name',
     },
     'language-selector': {
       'select-language': 'Select Language',


### PR DESCRIPTION
This release features:

- Additions:
  - New add Group component
- Modifications:
  - Groups are no longer fetched from mobsos but only from the contact service right now. Reasons for removal are that groups fetched from success modeling might be out of date if the network is restarted. 
  - Use Query visualization service caching of query requests
- Fixes:
  - Fix for constant refetching when data was not present
  - Fix preview view of the visualization
  - Fix measures not being stored correctly in the catalog of the current workspace
  - Fetch time for visualizations is now set even if an error occurred.
  - Fix value visualizations not being fetched from the server
  - Fix visualization components subscriptions not being unsubscribed from
- Other: 
  -  Redesign pick measure component so that measures can be added directly from the collapsed view without the need to first expand the panel
  - Charts now fade in when new data is loaded
  - Small style fixes 