### PR TITLE
Releases/v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobsos-evaluation-center",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -63,6 +63,7 @@ import { LanguageService } from './services/language.service';
 import { MatDialog } from '@angular/material/dialog';
 import { AddCommunityDialogComponent } from './add-community-dialog/add-community-dialog.component';
 import { StateEffects } from './services/store.effects';
+import { StoreState } from './models/state.model';
 
 // workaround for openidconned-signin
 // remove when the lib imports with "import {UserManager} from 'oidc-client';" instead of "import 'oidc-client';"
@@ -282,17 +283,19 @@ export class AppComponent implements OnInit, OnDestroy {
 
     if (isDevMode() || !environment.production) {
       // Logging in dev mode
-      // sub = this.ngrxStore.subscribe((state) => {
-      //   console.log(state);
-      // });
-      // this.subscriptions$.push(sub);
-
       sub = this.ngrxStore
-        .select(APPLICATION_WORKSPACE)
-        .subscribe((a) => {
-          console.log(a);
+        .pipe(map((store: StoreState) => store.Reducer))
+        .subscribe((state) => {
+          console.log(state);
         });
       this.subscriptions$.push(sub);
+
+      // sub = this.ngrxStore
+      //   .select(APPLICATION_WORKSPACE)
+      //   .subscribe((a) => {
+      //     console.log(a);
+      //   });
+      // this.subscriptions$.push(sub);
     }
   }
 

--- a/src/app/visualizations/chart-visualization/chart-visualization.component.ts
+++ b/src/app/visualizations/chart-visualization/chart-visualization.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { BaseVisualizationComponent } from '../visualization.component';
 import { MatDialog } from '@angular/material/dialog';
 import { Store } from '@ngrx/store';
@@ -43,7 +43,7 @@ import {
 })
 export class ChartVisualizerComponent
   extends BaseVisualizationComponent
-  implements OnInit
+  implements OnInit, OnDestroy
 {
   @Input() measureName: string;
 
@@ -60,6 +60,12 @@ export class ChartVisualizerComponent
     protected ngrxStore: Store,
   ) {
     super(ngrxStore, dialog);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((subscription) =>
+      subscription.unsubscribe(),
+    );
   }
 
   ngOnInit() {

--- a/src/app/visualizations/value-visualization/value-visualization.component.ts
+++ b/src/app/visualizations/value-visualization/value-visualization.component.ts
@@ -62,6 +62,12 @@ export class ValueVisualizationComponent
     super(ngrxStore, dialog);
   }
 
+  ngOnDestroy(): void {
+    this.subscriptions$.forEach((subscription) =>
+      subscription.unsubscribe(),
+    );
+  }
+
   ngOnInit() {
     // selects the measure from the measure catalog
     this.measure$ = this.ngrxStore

--- a/src/app/visualizations/visualization.component.ts
+++ b/src/app/visualizations/visualization.component.ts
@@ -99,6 +99,11 @@ export class BaseVisualizationComponent
     this.subscriptions$.push(sub);
   }
 
+  /** Note that lifecycle hooks are not called by components
+   * which inherit from this class
+   * Thus we need to unsubscribe from all subscriptions in the component itself
+   * as mentioned on @link https://medium.com/@saniyusuf/part-1-the-case-for-component-inheritance-in-angular-a34fe2a0f7ac
+   */
   ngOnDestroy(): void {
     this.subscriptions$.forEach((subscription) =>
       subscription.unsubscribe(),


### PR DESCRIPTION
This release features:

- Additions:
  - New add Group component
- Modifications:
  - Groups are no longer fetched from mobsos but only from the contact service right now. Reasons for removal are that groups fetched from success modeling might be out of date if the network is restarted. 
  - Use Query visualization service caching of query requests
- Fixes:
  - Fix for constant refetching when data was not present
  - Fix preview view of the visualization
  - Fix measures not being stored correctly in the catalog of the current workspace
  - Fetch time for visualizations is now set even if an error occurred.
  - Fix value visualizations not being fetched from the server
  - Fix visualization components subscriptions not being unsubscribed from
- Other: 
  -  Redesign pick measure component so that measures can be added directly from the collapsed view without the need to first expand the panel
  - Charts now fade in when new data is loaded
  - Small style fixes 